### PR TITLE
Per-player localization

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -228,7 +228,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
 
     public void reload() {
         reloadConfig();
-        Translator.load(getDataPath(), getConfig().getString("language", "en"));
+        Translator.loadAllTranslations(getDataPath(), getConfig().getString("language", "en"), getConfig().getBoolean("per-player-locale", true));
         this.useActionBar = getConfig().getBoolean("settings.use-action-bar", false);
         this.doors = getConfig().getConfigurationSection("doors") != null;
         this.doorsOpenIron = getConfig().getBoolean("doors.open-iron", false);

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminFindCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminFindCommand.java
@@ -67,8 +67,8 @@ public class AdminFindCommand extends BoltCommand {
             BoltComponents.sendMessage(
                     sender,
                     Translation.FIND_RESULT,
-                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(blockProtection)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(blockProtection)),
+                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(blockProtection, sender)),
+                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(blockProtection, sender)),
                     Placeholder.component(Translation.Placeholder.PLAYER, Component.text(playerProfile.name())),
                     Placeholder.component(Translation.Placeholder.TIME, Component.text(time)),
                     Placeholder.component(Translation.Placeholder.WORLD, Component.text(blockProtection.getWorld())),

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/EditCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/EditCommand.java
@@ -53,7 +53,7 @@ public class EditCommand extends BoltCommand {
                 player,
                 Translation.CLICK_ACTION,
                 plugin.isUseActionBar(),
-                Placeholder.component(Translation.Placeholder.ACTION, BoltComponents.resolveTranslation(Translation.EDIT))
+                Placeholder.component(Translation.Placeholder.ACTION, BoltComponents.resolveTranslation(Translation.EDIT, player))
         );
     }
 

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/LockCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/LockCommand.java
@@ -47,7 +47,7 @@ public class LockCommand extends BoltCommand {
                     player,
                     Translation.CLICK_ACTION,
                     plugin.isUseActionBar(),
-                    Placeholder.component(Translation.Placeholder.ACTION, BoltComponents.resolveTranslation(Translation.LOCK))
+                    Placeholder.component(Translation.Placeholder.ACTION, BoltComponents.resolveTranslation(Translation.LOCK, player))
             );
         } else {
             BoltComponents.sendMessage(sender, Translation.COMMAND_PLAYER_ONLY);

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModeCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModeCommand.java
@@ -48,7 +48,7 @@ public class ModeCommand extends BoltCommand {
             BoltComponents.sendMessage(
                     player,
                     hasMode ? Translation.MODE_ENABLED : Translation.MODE_DISABLED,
-                    Placeholder.component(Translation.Placeholder.MODE, BoltComponents.resolveTranslation("mode_%s".formatted(mode.name().toLowerCase())))
+                    Placeholder.component(Translation.Placeholder.MODE, BoltComponents.resolveTranslation("mode_%s".formatted(mode.name().toLowerCase()), player))
             );
             final UUID uuid = player.getUniqueId();
             CompletableFuture.runAsync(() -> {

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
@@ -111,7 +111,7 @@ public class ModifyCommand extends BoltCommand {
                     player,
                     Translation.CLICK_ACTION,
                     plugin.isUseActionBar(),
-                    Placeholder.component(Translation.Placeholder.ACTION, BoltComponents.resolveTranslation(Translation.EDIT))
+                    Placeholder.component(Translation.Placeholder.ACTION, BoltComponents.resolveTranslation(Translation.EDIT, player))
             );
         }
     }

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/UnlockCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/UnlockCommand.java
@@ -27,7 +27,7 @@ public class UnlockCommand extends BoltCommand {
                     player,
                     Translation.CLICK_ACTION,
                     plugin.isUseActionBar(),
-                    Placeholder.component(Translation.Placeholder.ACTION, BoltComponents.resolveTranslation(Translation.UNLOCK))
+                    Placeholder.component(Translation.Placeholder.ACTION, BoltComponents.resolveTranslation(Translation.UNLOCK, player))
             );
         } else {
             BoltComponents.sendMessage(sender, Translation.COMMAND_PLAYER_ONLY);

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -71,7 +71,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.popcraft.bolt.lang.Translator.translate;
+import static org.popcraft.bolt.util.BoltComponents.resolveTranslation;
+import static org.popcraft.bolt.util.BoltComponents.translateRaw;
 import static org.popcraft.bolt.util.Profiles.NIL_UUID;
 
 public final class BlockListener implements Listener {
@@ -123,7 +124,7 @@ public final class BlockListener implements Listener {
                             player,
                             Translation.LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                     );
                 }
             }
@@ -137,7 +138,7 @@ public final class BlockListener implements Listener {
                         return;
                     }
                     final boolean isYou = player.getUniqueId().equals(protection.getOwner());
-                    final String owner = isYou ? translate(Translation.YOU) : profile.name();
+                    final String owner = isYou ? translateRaw(Translation.YOU, player) : profile.name();
                     if (owner == null) {
                         SchedulerUtil.schedule(plugin, player, () -> {
                             if (!plugin.isProtected(clicked)) {
@@ -147,8 +148,8 @@ public final class BlockListener implements Listener {
                                     player,
                                     Translation.PROTECTION_NOTIFY_GENERIC,
                                     plugin.isUseActionBar(),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                             );
                         });
                     } else if (!isYou || player.hasPermission("bolt.protection.notify.self")) {
@@ -160,8 +161,8 @@ public final class BlockListener implements Listener {
                                     player,
                                     Translation.PROTECTION_NOTIFY,
                                     plugin.isUseActionBar(),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
                                     Placeholder.component(Translation.Placeholder.PLAYER, Component.text(owner))
                             );
                         });
@@ -224,14 +225,14 @@ public final class BlockListener implements Listener {
                                 player,
                                 Translation.CLICK_LOCKED_CHANGED,
                                 plugin.isUseActionBar(),
-                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection))
+                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player))
                         );
                     } else {
                         BoltComponents.sendMessage(
                                 player,
                                 Translation.CLICK_LOCKED_ALREADY,
                                 plugin.isUseActionBar(),
-                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                         );
                     }
                 } else if (plugin.isProtectable(block) && (!lockPermission || player.hasPermission("bolt.protection.lock.%s".formatted(block.getType().name().toLowerCase())))) {
@@ -242,15 +243,15 @@ public final class BlockListener implements Listener {
                             player,
                             Translation.CLICK_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection)),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block))
+                            Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection, player)),
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block, player))
                     );
                 } else {
                     BoltComponents.sendMessage(
                             player,
                             Translation.CLICK_NOT_LOCKABLE,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block, player))
                     );
                 }
             }
@@ -262,8 +263,8 @@ public final class BlockListener implements Listener {
                                 player,
                                 Translation.CLICK_UNLOCKED,
                                 plugin.isUseActionBar(),
-                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                         );
                     } else {
                         BoltComponents.sendMessage(
@@ -277,7 +278,7 @@ public final class BlockListener implements Listener {
                             player,
                             Translation.CLICK_NOT_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block, player))
                     );
                 }
             }
@@ -287,9 +288,9 @@ public final class BlockListener implements Listener {
                             .thenAccept(profile -> SchedulerUtil.schedule(plugin, player, () -> BoltComponents.sendMessage(
                                     player,
                                     protection.getAccess().size() > 0 && (protection.getOwner().equals(player.getUniqueId()) || player.hasPermission("bolt.command.info.full")) ? Translation.INFO_FULL : Translation.INFO,
-                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection)),
-                                    Placeholder.component(Translation.Placeholder.PLAYER, Component.text(Optional.ofNullable(profile.name()).orElse(translate(Translation.UNKNOWN)))),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PLAYER, Optional.ofNullable(profile.name()).<Component>map(Component::text).orElse(resolveTranslation(Translation.UNKNOWN, player))),
                                     Placeholder.component(Translation.Placeholder.ACCESS_LIST_SIZE, Component.text(protection.getAccess().size())),
                                     Placeholder.component(Translation.Placeholder.ACCESS_LIST, Component.text(Protections.accessList(protection.getAccess())))
                             )));
@@ -298,7 +299,7 @@ public final class BlockListener implements Listener {
                             player,
                             Translation.CLICK_NOT_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block, player))
                     );
                 }
             }
@@ -317,8 +318,8 @@ public final class BlockListener implements Listener {
                                 player,
                                 Translation.CLICK_EDITED,
                                 plugin.isUseActionBar(),
-                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                         );
                     } else {
                         BoltComponents.sendMessage(
@@ -332,7 +333,7 @@ public final class BlockListener implements Listener {
                             player,
                             Translation.CLICK_NOT_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block, player))
                     );
                 }
             }
@@ -351,9 +352,9 @@ public final class BlockListener implements Listener {
                                         player,
                                         Translation.CLICK_TRANSFER_CONFIRM,
                                         plugin.isUseActionBar(),
-                                        Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                        Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection)),
-                                        Placeholder.component(Translation.Placeholder.PLAYER, Component.text(Optional.ofNullable(profile.name()).orElse(translate(Translation.UNKNOWN))))
+                                        Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                        Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
+                                        Placeholder.component(Translation.Placeholder.PLAYER, Optional.ofNullable(profile.name()).<Component>map(Component::text).orElse(resolveTranslation(Translation.UNKNOWN, player)))
                                 )));
                     } else {
                         BoltComponents.sendMessage(player, Translation.CLICK_EDITED_NO_OWNER, plugin.isUseActionBar());
@@ -363,7 +364,7 @@ public final class BlockListener implements Listener {
                             player,
                             Translation.CLICK_NOT_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block, player))
                     );
                 }
             }
@@ -406,8 +407,8 @@ public final class BlockListener implements Listener {
                     player,
                     Translation.CLICK_LOCKED,
                     plugin.isUseActionBar(),
-                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block))
+                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection, player)),
+                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block, player))
             );
         }
     }
@@ -443,8 +444,8 @@ public final class BlockListener implements Listener {
                             player,
                             Translation.CLICK_UNLOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                            Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                     );
                 }
             }

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -70,7 +70,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.popcraft.bolt.lang.Translator.translate;
+import static org.popcraft.bolt.util.BoltComponents.resolveTranslation;
+import static org.popcraft.bolt.util.BoltComponents.translateRaw;
 import static org.popcraft.bolt.util.Profiles.NIL_UUID;
 
 public final class EntityListener implements Listener {
@@ -158,8 +159,8 @@ public final class EntityListener implements Listener {
                     player,
                     Translation.CLICK_LOCKED,
                     plugin.isUseActionBar(),
-                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity))
+                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection, player)),
+                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity, player))
             );
         }
     }
@@ -177,8 +178,8 @@ public final class EntityListener implements Listener {
                     player,
                     Translation.CLICK_UNLOCKED,
                     plugin.isUseActionBar(),
-                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
             );
         }
     }
@@ -232,8 +233,8 @@ public final class EntityListener implements Listener {
                             player,
                             Translation.CLICK_UNLOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                            Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                     );
                 }
             }
@@ -268,7 +269,7 @@ public final class EntityListener implements Listener {
                             player,
                             Translation.LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                     );
                 }
             }
@@ -279,7 +280,7 @@ public final class EntityListener implements Listener {
                         return;
                     }
                     final boolean isYou = player.getUniqueId().equals(protection.getOwner());
-                    final String owner = isYou ? translate(Translation.YOU) : profile.name();
+                    final String owner = isYou ? translateRaw(Translation.YOU, player) : profile.name();
                     if (owner == null) {
                         SchedulerUtil.schedule(plugin, player, () -> {
                             if (!plugin.isProtected(entity)) {
@@ -289,8 +290,8 @@ public final class EntityListener implements Listener {
                                     player,
                                     Translation.PROTECTION_NOTIFY_GENERIC,
                                     plugin.isUseActionBar(),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                             );
                         });
                     } else if (!isYou || player.hasPermission("bolt.protection.notify.self")) {
@@ -302,8 +303,8 @@ public final class EntityListener implements Listener {
                                     player,
                                     Translation.PROTECTION_NOTIFY,
                                     plugin.isUseActionBar(),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
                                     Placeholder.component(Translation.Placeholder.PLAYER, Component.text(owner))
                             );
                         });
@@ -343,14 +344,14 @@ public final class EntityListener implements Listener {
                                 player,
                                 Translation.CLICK_LOCKED_CHANGED,
                                 plugin.isUseActionBar(),
-                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection))
+                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player))
                         );
                     } else {
                         BoltComponents.sendMessage(
                                 player,
                                 Translation.CLICK_LOCKED_ALREADY,
                                 plugin.isUseActionBar(),
-                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                         );
                     }
                 } else if (plugin.isProtectable(entity) && (!lockPermission || player.hasPermission("bolt.protection.lock.%s".formatted(entity.getType().name().toLowerCase())))) {
@@ -361,15 +362,15 @@ public final class EntityListener implements Listener {
                             player,
                             Translation.CLICK_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection)),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity))
+                            Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection, player)),
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity, player))
                     );
                 } else {
                     BoltComponents.sendMessage(
                             player,
                             Translation.CLICK_NOT_LOCKABLE,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity, player))
                     );
                 }
             }
@@ -381,8 +382,8 @@ public final class EntityListener implements Listener {
                                 player,
                                 Translation.CLICK_UNLOCKED,
                                 plugin.isUseActionBar(),
-                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                         );
                     } else {
                         BoltComponents.sendMessage(
@@ -396,7 +397,7 @@ public final class EntityListener implements Listener {
                             player,
                             Translation.CLICK_NOT_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity, player))
                     );
                 }
             }
@@ -406,9 +407,9 @@ public final class EntityListener implements Listener {
                             .thenAccept(profile -> SchedulerUtil.schedule(plugin, player, () -> BoltComponents.sendMessage(
                                     player,
                                     protection.getAccess().size() > 0 && (protection.getOwner().equals(player.getUniqueId()) || player.hasPermission("bolt.command.info.full")) ? Translation.INFO_FULL : Translation.INFO,
-                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection)),
-                                    Placeholder.component(Translation.Placeholder.PLAYER, Component.text(Optional.ofNullable(profile.name()).orElse(translate(Translation.UNKNOWN)))),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PLAYER, Optional.ofNullable(profile.name()).<Component>map(Component::text).orElse(resolveTranslation(Translation.UNKNOWN, player))),
                                     Placeholder.component(Translation.Placeholder.ACCESS_LIST_SIZE, Component.text(protection.getAccess().size())),
                                     Placeholder.component(Translation.Placeholder.ACCESS_LIST, Component.text(Protections.accessList(protection.getAccess())))
                             )));
@@ -417,7 +418,7 @@ public final class EntityListener implements Listener {
                             player,
                             Translation.CLICK_NOT_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity, player))
                     );
                 }
             }
@@ -436,8 +437,8 @@ public final class EntityListener implements Listener {
                                 player,
                                 Translation.CLICK_EDITED,
                                 plugin.isUseActionBar(),
-                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                                Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
                         );
                     } else {
                         BoltComponents.sendMessage(
@@ -451,7 +452,7 @@ public final class EntityListener implements Listener {
                             player,
                             Translation.CLICK_NOT_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity, player))
                     );
                 }
             }
@@ -470,9 +471,9 @@ public final class EntityListener implements Listener {
                                         player,
                                         Translation.CLICK_TRANSFER_CONFIRM,
                                         plugin.isUseActionBar(),
-                                        Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                                        Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection)),
-                                        Placeholder.component(Translation.Placeholder.PLAYER, Component.text(Optional.ofNullable(profile.name()).orElse(translate(Translation.UNKNOWN))))
+                                        Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                                        Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
+                                        Placeholder.component(Translation.Placeholder.PLAYER, Optional.ofNullable(profile.name()).<Component>map(Component::text).orElse(resolveTranslation(Translation.UNKNOWN, player)))
                                 )));
                     } else {
                         BoltComponents.sendMessage(player, Translation.CLICK_EDITED_NO_OWNER, plugin.isUseActionBar());
@@ -482,7 +483,7 @@ public final class EntityListener implements Listener {
                             player,
                             Translation.CLICK_NOT_LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity, player))
                     );
                 }
             }
@@ -506,8 +507,8 @@ public final class EntityListener implements Listener {
                     player,
                     Translation.CLICK_UNLOCKED,
                     plugin.isUseActionBar(),
-                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection))
+                    Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
+                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
             );
         }
     }

--- a/bukkit/src/main/java/org/popcraft/bolt/util/BoltComponents.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/BoltComponents.java
@@ -8,6 +8,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import org.popcraft.bolt.lang.Translator;
 
 import java.util.Locale;
 
@@ -76,7 +77,7 @@ public final class BoltComponents {
      */
     public static Locale getLocaleOf(CommandSender sender) {
         if (sender instanceof Player player) {
-            return Locale.forLanguageTag(player.getLocale().replace('_', '-')); // reasons
+            return Translator.parseLocale(player.getLocale());
         } else {
             return new Locale("");
         }

--- a/bukkit/src/main/java/org/popcraft/bolt/util/BoltComponents.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/BoltComponents.java
@@ -6,7 +6,10 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+
+import java.util.Locale;
 
 import static org.popcraft.bolt.lang.Translator.translate;
 
@@ -33,22 +36,49 @@ public final class BoltComponents {
     }
 
     public static void sendMessage(final CommandSender sender, String key, TagResolver... placeholders) {
-        adventure.sender(sender).sendMessage(resolveTranslation(key, placeholders));
+        adventure.sender(sender).sendMessage(resolveTranslation(key, sender, placeholders));
     }
 
     public static void sendMessage(final CommandSender sender, String key, boolean actionBar, TagResolver... placeholders) {
         if (actionBar) {
-            adventure.sender(sender).sendActionBar(resolveTranslation(key, placeholders));
+            adventure.sender(sender).sendActionBar(resolveTranslation(key, sender, placeholders));
         } else {
-            adventure.sender(sender).sendMessage(resolveTranslation(key, placeholders));
+            adventure.sender(sender).sendMessage(resolveTranslation(key, sender, placeholders));
         }
     }
 
     public static void sendClickableMessage(final CommandSender sender, String key, ClickEvent clickEvent, TagResolver... placeholders) {
-        adventure.sender(sender).sendMessage(resolveTranslation(key, placeholders).clickEvent(clickEvent));
+        adventure.sender(sender).sendMessage(resolveTranslation(key, sender, placeholders).clickEvent(clickEvent));
     }
 
-    public static Component resolveTranslation(String key, TagResolver... placeholders) {
-        return miniMessage.deserialize(translate(key), placeholders);
+    public static Component resolveTranslation(final String key, final CommandSender sender, TagResolver... placeholders) {
+        return miniMessage.deserialize(translateRaw(key, sender), placeholders);
+    }
+
+    /**
+     * Translate a message with the given sender's locale. This method returns a string, usually a MiniMessage string,
+     * so it doesn't have formatting applied. See {@link #resolveTranslation(String, CommandSender, TagResolver...)}
+     * for the method which returns a Component.
+     * @param key translation key
+     * @param sender player to use the locale of
+     * @return localized string
+     */
+    public static String translateRaw(final String key, final CommandSender sender) {
+        return translate(key, getLocaleOf(sender));
+    }
+
+    /**
+     * Fetch the locale of a {@link CommandSender}. This will use the player's configured locale if the command sender
+     * is a {@link Player}, otherwise, it will fall back to an empty locale. The empty locale is translated to the
+     * language configured in the plugin config as the default language.
+     * @param sender command sender to check the locale of
+     * @return a locale, possibly an empty one
+     */
+    public static Locale getLocaleOf(CommandSender sender) {
+        if (sender instanceof Player player) {
+            return Locale.forLanguageTag(player.getLocale().replace('_', '-')); // reasons
+        } else {
+            return new Locale("");
+        }
     }
 }

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 version: 0
 language: en
+per-player-locale: true
 settings:
   use-action-bar: false
 database:

--- a/common/src/main/java/org/popcraft/bolt/lang/Translator.java
+++ b/common/src/main/java/org/popcraft/bolt/lang/Translator.java
@@ -1,48 +1,118 @@
 package org.popcraft.bolt.lang;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.logging.LogManager;
+import java.util.stream.Stream;
 
 public final class Translator {
     private static final String TRANSLATION_FILE_FORMAT = "lang/%s.properties";
     private static final Properties fallback = loadTranslation("en");
     private static Properties translation = loadTranslation("en");
-    private static Properties customTranslation = loadTranslation("en");
     private static String selected = "en";
+    private static boolean perPlayerLocale = true;
+    private static final Map<Locale, Properties> languages = new HashMap<>();
 
     private Translator() {
     }
 
-    public static boolean isTranslatable(final String key) {
-        return customTranslation.containsKey(key) || translation.containsKey(key) || fallback.containsKey(key);
-    }
-
-    public static String translate(final String key) {
-        return Objects.requireNonNullElseGet(customTranslation.getProperty(key), () -> Objects.requireNonNullElseGet(translation.getProperty(key), () -> Objects.requireNonNullElse(fallback.getProperty(key), key)));
-    }
-
-    public static void load(final Path directory, final String language) {
-        translation = loadTranslation(language);
-        final Path filePath = directory.resolve(language + ".properties");
-        customTranslation = loadTranslationFromFile(filePath);
-        if (!customTranslation.isEmpty()) {
-            selected = "custom";
-        } else if (!translation.isEmpty()) {
-            selected = language;
-        } else {
-            selected = "en";
+    public static boolean isTranslatable(final String key, final Locale locale) {
+        if (!perPlayerLocale) {
+            return translation.containsKey(key) || fallback.containsKey(key);
         }
+
+        return tryGetProperty(key, locale) != null
+            || tryGetProperty(key, new Locale(locale.getLanguage())) != null
+            || translation.containsKey(key)
+            || fallback.containsKey(key);
+    }
+
+    public static String translate(final String key, final Locale locale) {
+        if (!perPlayerLocale) {
+            return Objects.requireNonNullElseGet(translation.getProperty(key),
+                () -> Objects.requireNonNullElse(fallback.getProperty(key), key));
+        }
+
+        return Objects.requireNonNullElseGet(tryGetProperty(key, locale),
+            () -> Objects.requireNonNullElseGet(tryGetProperty(key, new Locale(locale.getLanguage())),
+                () -> Objects.requireNonNullElseGet(translation.getProperty(key),
+                    () -> Objects.requireNonNullElse(fallback.getProperty(key), key))));
+    }
+
+    private static String tryGetProperty(final String key, final Locale locale) {
+        final Properties properties = languages.get(locale);
+        if (properties == null) return null;
+
+        return properties.getProperty(key);
     }
 
     public static String selected() {
         return selected;
+    }
+
+    public static void loadAllTranslations(final Path directory, final String preferredLanguage, final boolean perPlayerLocales) {
+        final long startTimeNanos = System.nanoTime();
+
+        // Load all the localization files bundled with the jar
+        final ClassLoader classLoader = Translator.class.getClassLoader();
+        try {
+            // This is like using a bazooka to kill a fly (where the bazooka is "FileSystems" and the fly is
+            // "just loading all the translation files"
+            final URI uri = Objects.requireNonNull(classLoader.getResource("lang/")).toURI();
+            try (final FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+                 Stream<Path> walk = Files.walk(fileSystem.getPath("lang/"), 1)) {
+                for (Iterator<Path> it = walk.iterator(); it.hasNext();) {
+                    Path path = it.next();
+                    if (!path.toString().endsWith(".properties")) continue;
+
+                    final String localeName = path.getFileName().toString().split("\\.")[0].replace('_', '-');
+                    final Locale locale = Locale.forLanguageTag(localeName);
+                    final Properties properties = loadTranslation(locale.toString());
+                    languages.put(locale, properties);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+
+        // Load user-defined localization files. This is done after, so it overrides any built-in translations.
+        File[] files = directory.toFile().listFiles((dir, name) -> name.toLowerCase().endsWith(".properties"));
+        for (File file : Objects.requireNonNull(files)) {
+            final String localeName = file.getName().split("\\.")[0].replace('_', '-');
+            final Locale locale = Locale.forLanguageTag(localeName);
+            final Properties properties = loadTranslationFromFile(file.toPath());
+            languages.put(locale, properties);
+        }
+
+        // Load the preferred fallback language
+        translation = languages.getOrDefault(Locale.forLanguageTag(preferredLanguage.replace('_', '-')), fallback);
+
+        // This is no longer really that useful, but keep it around
+        selected = preferredLanguage;
+        perPlayerLocale = perPlayerLocales;
+
+        final long timeNanos = System.nanoTime() - startTimeNanos;
+        final double timeMillis = timeNanos / 1e6d;
+        LogManager.getLogManager().getLogger("").info(() -> "Loaded %d localization files in %.3f ms".formatted(languages.size(), timeMillis));
     }
 
     private static Properties loadTranslation(final String language) {

--- a/common/src/main/java/org/popcraft/bolt/lang/Translator.java
+++ b/common/src/main/java/org/popcraft/bolt/lang/Translator.java
@@ -82,8 +82,7 @@ public final class Translator {
                 files.forEach(path -> {
                     if (!path.toString().endsWith(".properties")) return;
 
-                    final String localeName = path.getFileName().toString().split("\\.")[0].replace('_', '-');
-                    final Locale locale = Locale.forLanguageTag(localeName);
+                    final Locale locale = parseLocale(path.getFileName().toString().split("\\.", 2)[0]);
                     final Properties properties = loadTranslation(locale.toString());
                     languages.put(locale, properties);
                 });
@@ -97,8 +96,7 @@ public final class Translator {
         // Load user-defined localization files. This is done after, so it overrides any built-in translations.
         try (Stream<Path> files = Files.list(directory).filter((name) -> name.toString().toLowerCase().endsWith(".properties"))) {
             files.forEach(path -> {
-                final String localeName = path.getFileName().toString().split("\\.")[0].replace('_', '-');
-                final Locale locale = Locale.forLanguageTag(localeName);
+                final Locale locale = parseLocale(path.getFileName().toString().split("\\.", 2)[0]);
                 final Properties properties = loadTranslationFromFile(path);
                 languages.put(locale, properties);
             });
@@ -107,7 +105,7 @@ public final class Translator {
         }
 
         // Load the preferred fallback language
-        translation = languages.getOrDefault(Locale.forLanguageTag(preferredLanguage.replace('_', '-')), fallback);
+        translation = languages.getOrDefault(parseLocale(preferredLanguage), fallback);
 
         // This is no longer really that useful, but keep it around
         selected = preferredLanguage;
@@ -142,5 +140,15 @@ public final class Translator {
             e.printStackTrace();
         }
         return properties;
+    }
+
+    public static Locale parseLocale(final String string) {
+        final String[] segments = string.split("_", 3);
+        return switch (segments.length) {
+            case 1 -> new Locale(string);
+            case 2 -> new Locale(segments[0], segments[1]);
+            case 3 -> new Locale(segments[0], segments[1], segments[2]);
+            default -> new Locale("");
+        };
     }
 }

--- a/common/src/main/java/org/popcraft/bolt/lang/Translator.java
+++ b/common/src/main/java/org/popcraft/bolt/lang/Translator.java
@@ -59,7 +59,9 @@ public final class Translator {
 
     private static String tryGetProperty(final String key, final Locale locale) {
         final Properties properties = languages.get(locale);
-        if (properties == null) return null;
+        if (properties == null) {
+            return null;
+        }
 
         return properties.getProperty(key);
     }
@@ -80,7 +82,9 @@ public final class Translator {
             try (final FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
                  Stream<Path> files = Files.list(fileSystem.getPath("lang/"))) {
                 files.forEach(path -> {
-                    if (!path.toString().endsWith(".properties")) return;
+                    if (!path.toString().endsWith(".properties")) {
+                        return;
+                    }
 
                     final Locale locale = parseLocale(path.getFileName().toString().split("\\.", 2)[0]);
                     final Properties properties = loadTranslation(locale.toString());

--- a/common/src/main/java/org/popcraft/bolt/lang/Translator.java
+++ b/common/src/main/java/org/popcraft/bolt/lang/Translator.java
@@ -97,6 +97,13 @@ public final class Translator {
             e.printStackTrace();
         }
 
+        // Use "custom" if the language used doesn't exist in the built-in set of languages
+        if (languages.containsKey(parseLocale(preferredLanguage))) {
+            selected = preferredLanguage;
+        } else {
+            selected = "custom";
+        }
+
         // Load user-defined localization files.
         try (Stream<Path> files = Files.list(directory)) {
             files.forEach(path -> {
@@ -118,8 +125,6 @@ public final class Translator {
         // Load the preferred fallback language
         translation = languages.getOrDefault(parseLocale(preferredLanguage), fallback);
 
-        // This is no longer really that useful, but keep it around
-        selected = preferredLanguage;
         perPlayerLocale = perPlayerLocales;
 
         final long timeNanos = System.nanoTime() - startTimeNanos;


### PR DESCRIPTION
This change allows for Bolt to display messages to the user in the language they have picked in the settings of their Minecraft client.

This is controlled by the new `per-player-locale` config option. The `language` config option is still used, even if per-player locales are enabled. It will be used as the fallback language if a player is using a language the server does not have localization for. It is also the language used for the console.

Additionally, multiple custom localization files can be provided. Any properties files placed in the plugin's data folder will all be loaded, with custom translations taking precedence over built-in ones.