### PR TITLE
Fix "Edited" message appearing when modify command is invalid

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/EditCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/EditCommand.java
@@ -35,7 +35,6 @@ public class EditCommand extends BoltCommand {
         }
         final BoltPlayer boltPlayer = plugin.player(player);
         final boolean adding = "add".equalsIgnoreCase(arguments.next());
-        boltPlayer.setAction(new Action(Action.Type.EDIT, "bolt.command.edit", Boolean.toString(adding)));
 
         final String target = arguments.next();
         final Profile playerProfile = Profiles.findOrLookupProfileByName(target).join();
@@ -48,6 +47,7 @@ public class EditCommand extends BoltCommand {
             return;
         }
         final Source source = Source.player(playerProfile.uuid());
+        boltPlayer.setAction(new Action(Action.Type.EDIT, "bolt.command.edit", Boolean.toString(adding)));
         boltPlayer.getModifications().put(source, plugin.getDefaultAccessType());
         BoltComponents.sendMessage(
                 player,

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
@@ -41,7 +41,6 @@ public class ModifyCommand extends BoltCommand {
         }
         final BoltPlayer boltPlayer = plugin.player(player);
         final boolean adding = "add".equalsIgnoreCase(arguments.next());
-        boltPlayer.setAction(new Action(Action.Type.EDIT, "bolt.command.edit", Boolean.toString(adding)));
         final String accessType = arguments.next().toLowerCase();
         final Access access = plugin.getBolt().getAccessRegistry().getAccessByType(accessType).orElse(null);
         if (access == null) {
@@ -70,6 +69,7 @@ public class ModifyCommand extends BoltCommand {
             BoltComponents.sendMessage(sender, Translation.EDIT_SOURCE_NO_PERMISSION);
             return;
         }
+        boltPlayer.setAction(new Action(Action.Type.EDIT, "bolt.command.edit", Boolean.toString(adding)));
         String identifier;
         while ((identifier = arguments.next()) != null) {
             final CompletableFuture<Source> editFuture;


### PR DESCRIPTION
Due to setting the action and setting modification separately, you can end up in a situation where executing an invalid modify command, for example `/bolt modify add asd asd`, says "invalid command", but when next clicking something, says "Edited", depite not actually editing anything.

This patch moves setAction calls downwards.