### PR TITLE
Fix wrong number of arguments for /bolt modify

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
@@ -35,7 +35,7 @@ public class ModifyCommand extends BoltCommand {
             BoltComponents.sendMessage(sender, Translation.COMMAND_PLAYER_ONLY);
             return;
         }
-        if (arguments.remaining() < 3) {
+        if (arguments.remaining() < 4) {
             shortHelp(sender, arguments);
             return;
         }


### PR DESCRIPTION
A modify command looks like this:
```
  /bolt modify add autoclose door door
                1      2      3    4
```
As seen, there must be at least 4 parameters (there can be more than 4) after popping off the /bolt modify prefix.
Currently, providing 3 arguments would pass the check but simply do nothing, exhibiting a bug similar to the one fixed by #106.