### PR TITLE
Don't do door stuff if denied interaction with door

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -184,6 +184,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
     private boolean doorsOpenIron;
     private boolean doorsOpenDouble;
     private int doorsCloseAfter;
+    private boolean doorsFixPlugins;
     private Bolt bolt;
 
     @Override
@@ -234,6 +235,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
         this.doorsOpenIron = getConfig().getBoolean("doors.open-iron", false);
         this.doorsOpenDouble = getConfig().getBoolean("doors.open-double", false);
         this.doorsCloseAfter = getConfig().getInt("doors.close-after", 0);
+        this.doorsFixPlugins = getConfig().getBoolean("doors.fix-plugins", false);
         registerAccessTypes();
         registerProtectableAccess();
         registerAccessSources();
@@ -504,6 +506,10 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
 
     public int getDoorsCloseAfter() {
         return doorsCloseAfter;
+    }
+
+    public boolean getDoorsFixPlugins() {
+        return doorsFixPlugins;
     }
 
     public ProfileCache getProfileCache() {

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -129,29 +129,8 @@ public final class BlockListener implements Listener {
                 }
             }
 
-            if (plugin.isDoors() && Doors.isDoor(e.getClickedBlock()) && canInteract) {
-                boolean denied = e.useInteractedBlock().equals(Event.Result.DENY);
-
-                final Block block = e.getClickedBlock();
-                final boolean leftClick = org.bukkit.event.block.Action.LEFT_CLICK_BLOCK.equals(e.getAction());
-                final boolean convertDoor = plugin.isDoorsOpenIron() && Doors.isIronDoor(block);
-
-                if (!denied && (leftClick || convertDoor)) {
-                    final var originalState = block.getState();
-                    if (convertDoor) {
-                        block.setType(Material.OAK_DOOR, false);
-                    }
-                    final var fakeInteract = new PlayerInteractEvent(player, org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK, e.getItem(), e.getClickedBlock(), e.getBlockFace());
-                    plugin.getServer().getPluginManager().callEvent(fakeInteract);
-                    denied = fakeInteract.useInteractedBlock().equals(Event.Result.DENY);
-                    if (convertDoor) {
-                        block.setBlockData(originalState.getBlockData(), false);
-                    }
-                }
-
-                if (!denied) {
-                    Doors.handlePlayerInteract(plugin, player, clicked);
-                }
+            if (plugin.isDoors() && canInteract) {
+                Doors.handlePlayerInteract(plugin, e);
             }
             if (hasNotifyPermission) {
                 Profiles.findOrLookupProfileByUniqueId(protection.getOwner()).thenAccept(profile -> {

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -128,8 +128,30 @@ public final class BlockListener implements Listener {
                     );
                 }
             }
-            if (plugin.isDoors() && canInteract) {
-                Doors.handlePlayerInteract(plugin, player, clicked);
+
+            if (plugin.isDoors() && Doors.isDoor(e.getClickedBlock()) && canInteract) {
+                boolean denied = e.useInteractedBlock().equals(Event.Result.DENY);
+
+                final Block block = e.getClickedBlock();
+                final boolean leftClick = org.bukkit.event.block.Action.LEFT_CLICK_BLOCK.equals(e.getAction());
+                final boolean convertDoor = plugin.isDoorsOpenIron() && Doors.isIronDoor(block);
+
+                if (!denied && (leftClick || convertDoor)) {
+                    final var originalState = block.getState();
+                    if (convertDoor) {
+                        block.setType(Material.OAK_DOOR, false);
+                    }
+                    final var fakeInteract = new PlayerInteractEvent(player, org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK, e.getItem(), e.getClickedBlock(), e.getBlockFace());
+                    plugin.getServer().getPluginManager().callEvent(fakeInteract);
+                    denied = fakeInteract.useInteractedBlock().equals(Event.Result.DENY);
+                    if (convertDoor) {
+                        block.setBlockData(originalState.getBlockData(), false);
+                    }
+                }
+
+                if (!denied) {
+                    Doors.handlePlayerInteract(plugin, player, clicked);
+                }
             }
             if (hasNotifyPermission) {
                 Profiles.findOrLookupProfileByUniqueId(protection.getOwner()).thenAccept(profile -> {

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -128,7 +128,6 @@ public final class BlockListener implements Listener {
                     );
                 }
             }
-
             if (plugin.isDoors() && canInteract) {
                 Doors.handlePlayerInteract(plugin, e);
             }

--- a/bukkit/src/main/java/org/popcraft/bolt/util/Doors.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Doors.java
@@ -77,6 +77,10 @@ public final class Doors {
     }
 
     public static boolean interactionDenied(final BoltPlugin plugin, final PlayerInteractEvent event) {
+        if (!plugin.getDoorsFixPlugins()) {
+            return false;
+        }
+
         final Block block = event.getClickedBlock();
         if (block == null) {
             return false;

--- a/bukkit/src/main/java/org/popcraft/bolt/util/Doors.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Doors.java
@@ -97,7 +97,7 @@ public final class Doors {
         }
 
         final boolean leftClick = org.bukkit.event.block.Action.LEFT_CLICK_BLOCK.equals(event.getAction());
-        final boolean ironDoor = plugin.isDoorsOpenIron() && isIronDoor(block);
+        final boolean ironDoor = plugin.isDoorsOpenIron() && !isDoorOpenableNormally(block);
 
         if (leftClick || ironDoor) {
             final BlockState originalState = block.getState();
@@ -164,10 +164,6 @@ public final class Doors {
         final boolean isIronDoor = Tag.DOORS.isTagged(material) && !Tag.WOODEN_DOORS.isTagged(material);
         final boolean isIronTrapdoor = Tag.TRAPDOORS.isTagged(material) && !Tag.WOODEN_TRAPDOORS.isTagged(material);
         return !isIronDoor && !isIronTrapdoor;
-    }
-
-    public static boolean isIronDoor(final Block block) {
-        return block.getType().equals(Material.IRON_DOOR) || block.getType().equals(Material.IRON_TRAPDOOR);
     }
 
     public static void toggleDoor(final Block block, final boolean canOpen) {

--- a/bukkit/src/main/java/org/popcraft/bolt/util/Doors.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Doors.java
@@ -115,6 +115,10 @@ public final class Doors {
         return !isIronDoor && !isIronTrapdoor;
     }
 
+    public static boolean isIronDoor(final Block block) {
+        return block.getType().equals(Material.IRON_DOOR) || block.getType().equals(Material.IRON_TRAPDOOR);
+    }
+
     public static void toggleDoor(final Block block, final boolean canOpen) {
         if (block.getBlockData() instanceof final Openable openable) {
             if (!canOpen && !openable.isOpen()) {


### PR DESCRIPTION
Fixes https://github.com/pop4959/Bolt/issues/95.

Hacky solution which fires fake interact events and changes door states
under the hood.