### PR TITLE
Don't allow dispensing items if redstone is disallowed

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -53,6 +53,7 @@ import org.popcraft.bolt.listeners.EntityListener;
 import org.popcraft.bolt.listeners.InventoryListener;
 import org.popcraft.bolt.listeners.PlayerListener;
 import org.popcraft.bolt.listeners.adapter.AnvilDamagedListener;
+import org.popcraft.bolt.listeners.adapter.BlockPreDispenseListener;
 import org.popcraft.bolt.listeners.adapter.PlayerRecipeBookClickListener;
 import org.popcraft.bolt.matcher.Match;
 import org.popcraft.bolt.matcher.block.AmethystClusterMatcher;
@@ -410,6 +411,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
         pluginManager.registerEvents(blockListener, this);
         if (PaperUtil.isPaper()) {
             pluginManager.registerEvents(new PlayerRecipeBookClickListener(blockListener::onPlayerRecipeBookClick), this);
+            pluginManager.registerEvents(new BlockPreDispenseListener(blockListener::onBlockPreDispense), this);
         }
         pluginManager.registerEvents(new EntityListener(this), this);
         final InventoryListener inventoryListener = new InventoryListener(this);

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -19,6 +19,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.block.BlockEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockFadeEvent;
 import org.bukkit.event.block.BlockFormEvent;
@@ -653,6 +654,10 @@ public final class BlockListener implements Listener {
         if (existingProtection == null) {
             return;
         }
+        if (!plugin.canAccess(existingProtection, REDSTONE_SOURCE_RESOLVER, Permission.REDSTONE)) {
+            e.setCancelled(true);
+            return;
+        }
         final BlockData blockData = block.getBlockData();
         if (!(blockData instanceof final Directional directional)) {
             return;
@@ -673,6 +678,20 @@ public final class BlockListener implements Listener {
             final BlockProtection newProtection = plugin.createProtection(placed, existingProtection.getOwner(), existingProtection.getType());
             plugin.saveProtection(newProtection);
         });
+    }
+
+    public void onBlockPreDispense(final BlockEvent e) {
+        if (!(e instanceof Cancellable cancellable)) {
+            return;
+        }
+        final Block block = e.getBlock();
+        final Protection existingProtection = plugin.findProtection(block);
+        if (existingProtection == null) {
+            return;
+        }
+        if (!plugin.canAccess(existingProtection, REDSTONE_SOURCE_RESOLVER, Permission.REDSTONE)) {
+            cancellable.setCancelled(true);
+        }
     }
 
     @EventHandler

--- a/paper/src/main/java/org/popcraft/bolt/listeners/adapter/BlockPreDispenseListener.java
+++ b/paper/src/main/java/org/popcraft/bolt/listeners/adapter/BlockPreDispenseListener.java
@@ -1,0 +1,15 @@
+package org.popcraft.bolt.listeners.adapter;
+
+import io.papermc.paper.event.block.BlockPreDispenseEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockEvent;
+
+import java.util.function.Consumer;
+
+public record BlockPreDispenseListener(Consumer<BlockEvent> handler) implements Listener {
+    @EventHandler
+    public void onBlockPreDispense(final BlockPreDispenseEvent e) {
+        handler.accept(e);
+    }
+}


### PR DESCRIPTION
Disallow removing items from dispensers and droppers by way of activating them and letting them shoot out their contents, if redstone isn't allowed for the dispenser or dropper.