### PR TITLE
Handle decorated pots

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -35,7 +35,6 @@ import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.event.block.LeavesDecayEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.block.SpongeAbsorbEvent;
-import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
@@ -82,6 +81,7 @@ public final class BlockListener implements Listener {
     private static final Material CHISELED_BOOKSHELF = EnumUtil.valueOf(Material.class, "CHISELED_BOOKSHELF").orElse(null);
     private static final Material SCULK_SENSOR = EnumUtil.valueOf(Material.class, "SCULK_SENSOR").orElse(null);
     private static final Material CALIBRATED_SCULK_SENSOR = EnumUtil.valueOf(Material.class, "CALIBRATED_SCULK_SENSOR").orElse(null);
+    private static final Material DECORATED_POT = EnumUtil.valueOf(Material.class, "DECORATED_POT").orElse(null);
     private final BoltPlugin plugin;
 
     public BlockListener(final BoltPlugin plugin) {
@@ -189,6 +189,12 @@ public final class BlockListener implements Listener {
                         e.setUseItemInHand(Event.Result.DENY);
                         e.setUseInteractedBlock(Event.Result.DENY);
                     }
+                }
+            }
+            if (DECORATED_POT != null && DECORATED_POT.equals(clicked.getType()) && e.getItem() != null) {
+                if (!plugin.canAccess(protection, player, Permission.DEPOSIT)) {
+                    e.setUseItemInHand(Event.Result.DENY);
+                    e.setUseInteractedBlock(Event.Result.DENY);
                 }
             }
             boltPlayer.setInteracted(shouldCancel);
@@ -485,20 +491,6 @@ public final class BlockListener implements Listener {
             return;
         }
         e.getBlocks().removeIf(blockState -> plugin.isProtected(blockState.getBlock()));
-    }
-
-    @EventHandler
-    public void onEntityChangeBlock(final EntityChangeBlockEvent e) {
-        if (Tag.DOORS.isTagged(e.getBlock().getType())) {
-            return;
-        }
-        final Protection protection = plugin.findProtection(e.getBlock());
-        if (protection == null) {
-            return;
-        }
-        if (!(e.getEntity() instanceof final Player player) || !plugin.canAccess(protection, player, Permission.INTERACT)) {
-            e.setCancelled(true);
-        }
     }
 
     @EventHandler

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -2,7 +2,9 @@ package org.popcraft.bolt.listeners;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
@@ -16,6 +18,7 @@ import org.bukkit.event.block.BlockShearEntityEvent;
 import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityBreakDoorEvent;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityCombustByBlockEvent;
 import org.bukkit.event.entity.EntityCombustByEntityEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -775,6 +778,26 @@ public final class EntityListener implements Listener {
         }
         if (!plugin.canAccess(protection, ENTITY_SOURCE_RESOLVER, Permission.ENTITY_BREAK_DOOR)) {
             e.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onEntityChangeBlock(final EntityChangeBlockEvent e) {
+        if (Tag.DOORS.isTagged(e.getBlock().getType())) {
+            return;
+        }
+        final Protection protection = plugin.findProtection(e.getBlock());
+        if (protection == null) {
+            return;
+        }
+        // This event is called for decorated pots broken by an arrow. WATER is needed for waterlogged decorated pots.
+        final boolean broken = e.getTo().equals(Material.AIR) || e.getTo().equals(Material.WATER);
+        if (!(getDamagerSource(e.getEntity()) instanceof final Player player) || !plugin.canAccess(protection, player, broken ? Permission.DESTROY : Permission.INTERACT)) {
+            e.setCancelled(true);
+            return;
+        }
+        if (broken) {
+            plugin.removeProtection(protection);
         }
     }
 

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -78,6 +78,8 @@ blocks:
     autoProtect: private
   hopper:
     autoProtect: private
+  decorated_pot:
+    autoProtect: private
   '#shulker_boxes':
     autoProtect: private
   '#anvil':


### PR DESCRIPTION
Since 1.20.3, decorated pots have 1 stack of inventory. Handle events for depositing them and breaking them with an arrow. Adds decorated pots to the default config.yml