### PR TITLE
Add permission checks to globally bypass permissions

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -758,7 +758,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
                 }
             }
         }
-        unresolved.removeIf(permission -> sourceResolver.resolve(Source.of(SourceTypes.PERMISSION, "bolt.bypass." + permission)));
+        unresolved.removeIf(permission -> sourceResolver.resolve(Source.of(SourceTypes.PERMISSION, "bolt.permission." + permission)));
         return unresolved.isEmpty();
     }
 

--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -758,6 +758,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
                 }
             }
         }
+        unresolved.removeIf(permission -> sourceResolver.resolve(Source.of(SourceTypes.PERMISSION, "bolt.bypass." + permission)));
         return unresolved.isEmpty();
     }
 


### PR DESCRIPTION
Add bukkit permissions that bypass bolt permissions. Permissions within permissions!

I think this fixes #98. If you want to give your moderators the ability to open chests, you can give them the permissions `bolt.permission.interact` and `bolt.permission.open`. In this case, they wouldn't be able to take or remove things, for that you'd need to `deposit` and `withdraw` permissions. To give someone the permission to unlock protections, you'd need to give them `bolt.permission.destroy`.