### PR TITLE
Refactor mod permission

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -171,6 +171,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
             new HangingSignMatcher(), new PinkPetalsMatcher());
     private static final List<EntityMatcher> ENTITY_MATCHERS = List.of();
     private static final Source ADMIN_PERMISSION_SOURCE = Source.of(SourceTypes.PERMISSION, "bolt.admin");
+    private static final Source MOD_PERMISSION_SOURCE = Source.of(SourceTypes.PERMISSION, "bolt.mod");
     private final List<BlockMatcher> enabledBlockMatchers = new ArrayList<>();
     private final List<EntityMatcher> enabledEntityMatchers = new ArrayList<>();
     private final Map<String, BoltCommand> commands = new HashMap<>();
@@ -721,6 +722,12 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
         final Source ownerSource = Source.player(protection.getOwner());
         if (sourceResolver.resolve(ownerSource) || sourceResolver.resolve(ADMIN_PERMISSION_SOURCE)) {
             unresolved.removeAll(DefaultAccess.OWNER);
+            if (unresolved.isEmpty()) {
+                return true;
+            }
+        }
+        if (sourceResolver.resolve(MOD_PERMISSION_SOURCE)) {
+            unresolved.removeAll(DefaultAccess.DISPLAY);
             if (unresolved.isEmpty()) {
                 return true;
             }

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -264,7 +264,7 @@ public final class BlockListener implements Listener {
             }
             case UNLOCK -> {
                 if (protection != null) {
-                    if (player.hasPermission("bolt.mod") || plugin.canAccess(protection, player, Permission.DESTROY)) {
+                    if (plugin.canAccess(protection, player, Permission.DESTROY)) {
                         plugin.removeProtection(protection);
                         BoltComponents.sendMessage(
                                 player,

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -382,7 +382,7 @@ public final class EntityListener implements Listener {
             }
             case UNLOCK -> {
                 if (protection != null) {
-                    if (player.hasPermission("bolt.mod") || plugin.canAccess(protection, player, Permission.DESTROY)) {
+                    if (plugin.canAccess(protection, player, Permission.DESTROY)) {
                         plugin.removeProtection(protection);
                         BoltComponents.sendMessage(
                                 player,


### PR DESCRIPTION
No longer allows unlocking (a destructive action), instead only allows looking (but not modifying) protections.