### PR TITLE
Optimize canAccess

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/BoltAPI.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltAPI.java
@@ -14,6 +14,7 @@ import org.popcraft.bolt.source.SourceResolver;
 import java.util.Collection;
 import java.util.UUID;
 
+@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 public interface BoltAPI {
     boolean isProtectable(final Block block);
 
@@ -47,10 +48,8 @@ public interface BoltAPI {
 
     Collection<Protection> findProtections(final World world, final BoundingBox boundingBox);
 
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     boolean canAccess(final Block block, final Player player, final String... permissions);
 
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     boolean canAccess(final Entity entity, final Player player, final String... permissions);
 
     boolean canAccess(final Protection protection, final Player player, final String... permissions);
@@ -58,6 +57,16 @@ public interface BoltAPI {
     boolean canAccess(final Protection protection, final UUID uuid, final String... permissions);
 
     boolean canAccess(final Protection protection, final SourceResolver sourceResolver, String... permissions);
+
+    boolean canAccess(final Block block, final Player player, final String permission);
+
+    boolean canAccess(final Entity entity, final Player player, final String permission);
+
+    boolean canAccess(final Protection protection, final Player player, final String permission);
+
+    boolean canAccess(final Protection protection, final UUID uuid, final String permission);
+
+    boolean canAccess(Protection protection, SourceResolver sourceResolver, String permission);
 
     void registerPlayerSourceResolver(final PlayerSourceResolver playerSourceResolver);
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/BoltAPI.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltAPI.java
@@ -56,17 +56,7 @@ public interface BoltAPI {
 
     boolean canAccess(final Protection protection, final UUID uuid, final String... permissions);
 
-    boolean canAccess(final Protection protection, final SourceResolver sourceResolver, String... permissions);
-
-    boolean canAccess(final Block block, final Player player, final String permission);
-
-    boolean canAccess(final Entity entity, final Player player, final String permission);
-
-    boolean canAccess(final Protection protection, final Player player, final String permission);
-
-    boolean canAccess(final Protection protection, final UUID uuid, final String permission);
-
-    boolean canAccess(Protection protection, SourceResolver sourceResolver, String permission);
+    boolean canAccess(final Protection protection, final SourceResolver sourceResolver, final String... permissions);
 
     void registerPlayerSourceResolver(final PlayerSourceResolver playerSourceResolver);
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -715,16 +715,13 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
 
     @Override
     public boolean canAccess(final Protection protection, final SourceResolver sourceResolver, final String... permissions) {
-        if (permissions.length == 0) {
+        if (protection == null || permissions.length == 0) {
             return true;
         }
         return permissions.length == 1 ? canAccessSingle(protection, sourceResolver, permissions[0]) : canAccessMulti(protection, sourceResolver, permissions);
     }
 
     private boolean canAccessMulti(final Protection protection, final SourceResolver sourceResolver, final String... permissions) {
-        if (protection == null) {
-            return true;
-        }
         final Set<String> unresolved = new HashSet<>(Arrays.asList(permissions));
         final Source ownerSource = Source.player(protection.getOwner());
         if (sourceResolver.resolve(ownerSource) || sourceResolver.resolve(ADMIN_PERMISSION_SOURCE)) {
@@ -777,9 +774,6 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
     }
 
     private boolean canAccessSingle(final Protection protection, final SourceResolver sourceResolver, final String permission) {
-        if (protection == null) {
-            return true;
-        }
         final Source ownerSource = Source.player(protection.getOwner());
         if (sourceResolver.resolve(ownerSource) || sourceResolver.resolve(ADMIN_PERMISSION_SOURCE)) {
             if (DefaultAccess.OWNER.contains(permission)) {

--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -714,7 +714,14 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
     }
 
     @Override
-    public boolean canAccess(final Protection protection, final SourceResolver sourceResolver, String... permissions) {
+    public boolean canAccess(final Protection protection, final SourceResolver sourceResolver, final String... permissions) {
+        if (permissions.length == 0) {
+            return true;
+        }
+        return permissions.length == 1 ? canAccessSingle(protection, sourceResolver, permissions[0]) : canAccessMulti(protection, sourceResolver, permissions);
+    }
+
+    private boolean canAccessMulti(final Protection protection, final SourceResolver sourceResolver, final String... permissions) {
         if (protection == null) {
             return true;
         }
@@ -769,28 +776,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
         return unresolved.isEmpty();
     }
 
-    @Override
-    public boolean canAccess(final Block block, final Player player, final String permission) {
-        return canAccess(findProtection(block), player.getUniqueId(), permission);
-    }
-
-    @Override
-    public boolean canAccess(final Entity entity, final Player player, final String permission) {
-        return canAccess(findProtection(entity), player.getUniqueId(), permission);
-    }
-
-    @Override
-    public boolean canAccess(final Protection protection, final Player player, final String permission) {
-        return canAccess(protection, player.getUniqueId(), permission);
-    }
-
-    @Override
-    public boolean canAccess(final Protection protection, final UUID uuid, final String permission) {
-        return canAccess(protection, new BukkitPlayerResolver(bolt, uuid), permission);
-    }
-
-    @Override
-    public boolean canAccess(final Protection protection, final SourceResolver sourceResolver, String permission) {
+    private boolean canAccessSingle(final Protection protection, final SourceResolver sourceResolver, final String permission) {
         if (protection == null) {
             return true;
         }


### PR DESCRIPTION
Adds single-permission lookups for canAccess. This optimizes the lookup since it reduces operations on sets.
Based on my testing, this gives at least a 2x speed-up, if not more. Note that canAccess isn't a very heavy method; for example, findProtection is about 80x heavier than canAccess.