### PR TITLE
Prevent claimed blocks from being destroyed

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -53,6 +53,7 @@ import org.popcraft.bolt.listeners.EntityListener;
 import org.popcraft.bolt.listeners.InventoryListener;
 import org.popcraft.bolt.listeners.PlayerListener;
 import org.popcraft.bolt.listeners.adapter.AnvilDamagedListener;
+import org.popcraft.bolt.listeners.adapter.BlockDestroyListener;
 import org.popcraft.bolt.listeners.adapter.BlockPreDispenseListener;
 import org.popcraft.bolt.listeners.adapter.PlayerRecipeBookClickListener;
 import org.popcraft.bolt.matcher.Match;
@@ -436,6 +437,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
         if (PaperUtil.isPaper()) {
             pluginManager.registerEvents(new PlayerRecipeBookClickListener(blockListener::onPlayerRecipeBookClick), this);
             pluginManager.registerEvents(new BlockPreDispenseListener(blockListener::onBlockPreDispense), this);
+            pluginManager.registerEvents(new BlockDestroyListener(blockListener::onBlockDestroy), this);
         }
         pluginManager.registerEvents(new EntityListener(this), this);
         final InventoryListener inventoryListener = new InventoryListener(this);

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -686,6 +686,22 @@ public final class BlockListener implements Listener {
         }
     }
 
+    // BlockDestroyEvent is called when a block is about to be destroyed. We use it here to prevent a protected block
+    // from becoming destroyed involuntarily, for example, because it is a door and its support was removed. For other
+    // cases, like just breaking the door itself, it will go through other events and be handled properly.
+    // This is a last resort event.
+    public void onBlockDestroy(final BlockEvent e) {
+        if (!(e instanceof Cancellable cancellable)) {
+            return;
+        }
+        final Block block = e.getBlock();
+        final Protection existingProtection = plugin.findProtection(block);
+        if (existingProtection == null) {
+            return;
+        }
+        cancellable.setCancelled(true);
+    }
+
     @EventHandler
     public void onBlockReceiveGameEvent(final BlockReceiveGameEvent e) {
         if (!(e.getEntity() instanceof final Player player)) {

--- a/paper/src/main/java/org/popcraft/bolt/listeners/adapter/BlockDestroyListener.java
+++ b/paper/src/main/java/org/popcraft/bolt/listeners/adapter/BlockDestroyListener.java
@@ -1,0 +1,16 @@
+package org.popcraft.bolt.listeners.adapter;
+
+import com.destroystokyo.paper.event.block.BlockDestroyEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockEvent;
+
+import java.util.function.Consumer;
+
+public record BlockDestroyListener(Consumer<BlockEvent> handler) implements Listener {
+    @EventHandler
+    public void onBlockDestroy(final BlockDestroyEvent e) {
+        handler.accept(e);
+    }
+}
+


### PR DESCRIPTION
BlockDestroyEvent is called when a block is about to be destroyed. We use it here to prevent a protected block from becoming destroyed involuntarily, for example, because it is a door and its support was removed. For other cases, like just breaking the door itself, it will go through other events and be handled properly

Handling BlockDestroyEvent is a last resort, it means the block would be destroyed by an action not able to be handled through any other event.

This fix avoids ghost claims.