### PR TITLE
Allow bolt admin cleanup to run multiple times

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminCleanup.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminCleanup.java
@@ -101,6 +101,7 @@ public class AdminCleanup extends BoltCommand {
                     Placeholder.component(Translation.Placeholder.COUNT, Component.text(removed.get())),
                     Placeholder.component(Translation.Placeholder.SECONDS, Component.text(seconds))
             );
+            WORKING.release(PERMITS);
         }, SchedulerUtil.executor(plugin, sender));
     }
 


### PR DESCRIPTION
The command `/bolt admin cleanup` uses a Semaphore internally. When running them command, it will acquire all permits at the end to wait for the command to finish. But it never releases those.

This patch makes the command release the permits it acquired.