### PR TITLE
Prevent gradle from caching the version

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
 tasks {
     processResources {
+        inputs.property("version", project.version)
         filesMatching("plugin.yml") {
             expand(
                 "name" to project.property("artifactName"),


### PR DESCRIPTION
This prevents stale version numbers in plugin.yml if not doing a clean build.