### PR TITLE
Fix door matcher checking too low

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/matcher/block/DoorMatcher.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/matcher/block/DoorMatcher.java
@@ -48,10 +48,10 @@ public class DoorMatcher implements BlockMatcher {
             final Block lowerHalf = block.getRelative(BlockFace.UP);
             if (lowerHalf.getBlockData() instanceof Door) {
                 blocks.add(lowerHalf);
-            }
-            final Block upperHalf = lowerHalf.getRelative(BlockFace.UP);
-            if (upperHalf.getBlockData() instanceof Door) {
-                blocks.add(upperHalf);
+                final Block upperHalf = lowerHalf.getRelative(BlockFace.UP);
+                if (upperHalf.getBlockData() instanceof Door) {
+                    blocks.add(upperHalf);
+                }
             }
         }
         return Match.ofBlocks(blocks);


### PR DESCRIPTION
The DoorMatcher would lock a block 2 blocks below the actual door. This fixes that behaviour.