### PR TITLE
Allow bees to work in locked beehives

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -6,6 +6,7 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -609,6 +610,10 @@ public final class EntityListener extends InteractionListener implements Listene
         }
         final Protection protection = plugin.findProtection(e.getBlock());
         if (protection == null) {
+            return;
+        }
+        // This event is called if a bee in a nest produces honey. We don't want to block that.
+        if (e.getEntity().getType() == EntityType.BEE && e.getBlock().getType() == e.getTo() && (e.getTo().equals(Material.BEE_NEST) || e.getTo().equals(Material.BEEHIVE))) {
             return;
         }
         // This event is called for decorated pots broken by an arrow. WATER is needed for waterlogged decorated pots.


### PR DESCRIPTION
Currently, bees can freely enter and leave locked beehives and bee nests, but any honey they produce gets cancelled.

This patch allows bees to alter the honey levels of locked beehives.

Future patches may consider blocking bees to enter beehives locked at "private", and require you to lock it at "deposit" to allow bees to enter and work. This patch doesn't propose such mechanics yet.

Fixes #153