### PR TITLE
Prevent Duplicated Handling of EntityDamageByEntityEvent

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -409,6 +409,10 @@ public final class EntityListener extends InteractionListener implements Listene
 
     @EventHandler
     public void onEntityDamage(final EntityDamageEvent e) {
+        if (e instanceof EntityDamageByEntityEvent) {
+            // EntityDamageByEntityEvent is already handled in onEntityDamageByEntity
+            return;
+        }
         if (EntityDamageEvent.DamageCause.ENTITY_ATTACK.equals(e.getCause()) || EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK.equals(e.getCause()) || EntityDamageEvent.DamageCause.PROJECTILE.equals(e.getCause()) || EntityDamageEvent.DamageCause.ENTITY_EXPLOSION.equals(e.getCause())) {
             return;
         }


### PR DESCRIPTION
This PR addresses the issue where `EntityDamageByEntityEvent` is handled twice due to it also passing through `EntityDamageEvent` listeners. `onEntityDamage(EntityDamageEvent)` now exits immediately if the event is actually an instance of `EntityDamageByEntityEvent`.