### PR TITLE
Expose bolt-common from bolt-bukkit as API

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     }
     implementation(group = "org.bstats", name = "bstats-bukkit", version = "3.0.2")
     implementation(group = "org.popcraft", name = "chunky-nbt", version = "1.3.127")
-    implementation(project(":bolt-common"))
+    api(project(":bolt-common"))
     implementation(project(":bolt-paper"))
     implementation(project(":bolt-folia"))
 }


### PR DESCRIPTION
Currently, you must depend on bolt-bukkit and bolt-common at the same time, because API methods from bolt-bukkit depend on classes from bolt-common, and without having both dependencies, some things cannot be used.

This patch upgrades the dependency from implementation to api, allowing consmers of bolt-bukkit to use bolt-common classes in the compile-time class path.