### PR TITLE
Fix block protection type mismatch with waxing

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -633,8 +633,7 @@ public final class EntityListener extends InteractionListener implements Listene
         }
         // This event is called for waxing or axing a copper block. We need to update the protection to avoid mismatches.
         // TODO: this might need to be monitor?
-        final BlockProtection blockProtection = plugin.loadProtection(e.getBlock());
-        if (blockProtection != null && e.getBlock().getType() != e.getTo()) {
+        if (protection instanceof final BlockProtection blockProtection && blockProtection.getBlock().equals(e.getBlock().getType().name()) && e.getBlock().getType() != e.getTo()) {
             blockProtection.setBlock(e.getTo().name());
             plugin.saveProtection(blockProtection);
         }

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -631,8 +631,15 @@ public final class EntityListener extends InteractionListener implements Listene
         if (broken) {
             plugin.removeProtection(protection);
         }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onEntityChangeBlockMonitor(final EntityChangeBlockEvent e) {
+        final Protection protection = plugin.findProtection(e.getBlock());
+        if (protection == null || !(e.getEntity() instanceof Player) || e.getTo().isAir()) {
+            return;
+        }
         // This event is called for waxing or axing a copper block. We need to update the protection to avoid mismatches.
-        // TODO: this might need to be monitor?
         if (protection instanceof final BlockProtection blockProtection && blockProtection.getBlock().equals(e.getBlock().getType().name()) && e.getBlock().getType() != e.getTo()) {
             blockProtection.setBlock(e.getTo().name());
             plugin.saveProtection(blockProtection);

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -633,7 +633,7 @@ public final class EntityListener extends InteractionListener implements Listene
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityChangeBlockMonitor(final EntityChangeBlockEvent e) {
         final Protection protection = plugin.findProtection(e.getBlock());
         if (protection == null || !(e.getEntity() instanceof Player) || e.getTo().isAir()) {

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -54,6 +54,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.popcraft.bolt.BoltPlugin;
 import org.popcraft.bolt.access.Access;
 import org.popcraft.bolt.lang.Translation;
+import org.popcraft.bolt.protection.BlockProtection;
 import org.popcraft.bolt.protection.EntityProtection;
 import org.popcraft.bolt.protection.Protection;
 import org.popcraft.bolt.source.Source;
@@ -609,7 +610,8 @@ public final class EntityListener extends InteractionListener implements Listene
 
     @EventHandler
     public void onEntityChangeBlock(final EntityChangeBlockEvent e) {
-        if (Tag.DOORS.isTagged(e.getBlock().getType())) {
+        // This event is called for zombies breaking doors, but it's already handled by EntityBreakDoorEvent.
+        if (Tag.DOORS.isTagged(e.getBlock().getType()) && e.getTo().isAir()) {
             return;
         }
         final Protection protection = plugin.findProtection(e.getBlock());
@@ -628,6 +630,13 @@ public final class EntityListener extends InteractionListener implements Listene
         }
         if (broken) {
             plugin.removeProtection(protection);
+        }
+        // This event is called for waxing or axing a copper block. We need to update the protection to avoid mismatches.
+        // TODO: this might need to be monitor?
+        final BlockProtection blockProtection = plugin.loadProtection(e.getBlock());
+        if (blockProtection != null && e.getBlock().getType() != e.getTo()) {
+            blockProtection.setBlock(e.getTo().name());
+            plugin.saveProtection(blockProtection);
         }
     }
 


### PR DESCRIPTION
When waxing or unwaxing a copper block, the entire type of the block changes. This causes the block stored in bolt to desync from what the actual block is. This causes no issues normally, but causes the protection to be deleted when running `/bolt admin cleanup`.

This patch fixes such desyncs.