### PR TITLE
Allow bolt admin find to find entities

### DIFF
--- a/common/src/main/java/org/popcraft/bolt/lang/Translation.java
+++ b/common/src/main/java/org/popcraft/bolt/lang/Translation.java
@@ -41,6 +41,7 @@ public class Translation {
     public static final String FIND_HEADER = "find_header";
     public static final String FIND_HEADER_NEW = "find_header_new";
     public static final String FIND_RESULT = "find_result";
+    public static final String FIND_RESULT_UNKNOWN = "find_result_unknown";
     public static final String FIND_TELEPORT = "find_teleport";
     public static final String FIND_NEXT = "find_next";
     public static final String FIND_NEXT_NEW = "find_next_new";

--- a/common/src/main/resources/lang/en.properties
+++ b/common/src/main/resources/lang/en.properties
@@ -38,6 +38,7 @@ expire_invalid_time=<red>You need to enter a valid time!</red>
 find_header=Found results:
 find_header_new=Showing results <yellow><first></yellow> - <yellow><last></yellow> of <yellow><count></yellow>:
 find_result=<yellow><protection_type></yellow> <yellow><protection></yellow> locked by <yellow><player></yellow> created <yellow><time></yellow><newline><command><gray>Located in <world> at <x>, <y>, <z></gray></command>
+find_result_unknown=<yellow><protection_type></yellow> <yellow><protection></yellow> locked by <yellow><player></yellow> created <yellow><time></yellow><newline><gray>Unknown location, <protection> is not loaded</gray>
 find_teleport=Click to teleport
 find_next=Click to view more
 find_next_new=[<pages> ... <page>]


### PR DESCRIPTION
All entities will be included in the output, including unloaded ones. Unloaded ones simply won't have their location listed.

![image](https://github.com/user-attachments/assets/2ba00ba7-3a44-455e-9b11-eb1b1d238bb2)
