### PR TITLE
Source transformers

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/BoltAPI.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltAPI.java
@@ -11,6 +11,7 @@ import org.popcraft.bolt.protection.EntityProtection;
 import org.popcraft.bolt.protection.Protection;
 import org.popcraft.bolt.source.PlayerSourceResolver;
 import org.popcraft.bolt.source.SourceResolver;
+import org.popcraft.bolt.source.SourceTransformer;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -184,4 +185,12 @@ public interface BoltAPI {
      * Registers an event listener for the given event class.
      */
     <T extends Event> void registerListener(final Class<T> clazz, final Consumer<? super T> listener);
+
+    /**
+     * Registers a source transformer for the provided source type. This allows for custom source types with ergonomic
+     * command usage.
+     *
+     * @see SourceTransformer
+     */
+    void registerSourceTransformer(final String sourceType, final SourceTransformer sourceTransformer);
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -911,30 +911,7 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
         this.sourceTransformers.put(SourceTypes.GROUP, new GroupSourceTransformer(this));
     }
 
-    public CompletableFuture<Source> transformSource(String type, String identifier, CommandSender sender) {
-        final SourceTransformer transformer = this.sourceTransformers.get(type);
-        if (transformer != null) {
-            return transformer.transformIdentifier(identifier, sender).thenApply(id -> Source.of(type, id));
-        } else {
-            return CompletableFuture.completedFuture(Source.of(type, identifier));
-        }
-    }
-
-    public List<String> completeSource(String type, CommandSender sender) {
-        final SourceTransformer transformer = this.sourceTransformers.get(type);
-        if (transformer != null) {
-            return transformer.completions(sender);
-        } else {
-            return List.of();
-        }
-    }
-
-    public String unTransformSource(Source source, CommandSender sender) {
-        final SourceTransformer transformer = this.sourceTransformers.get(source.getType());
-        if (transformer != null) {
-            return transformer.unTransformIdentifier(source.getIdentifier(), sender);
-        } else {
-            return source.getIdentifier();
-        }
+    public SourceTransformer getSourceTransformer(String type) {
+        return this.sourceTransformers.getOrDefault(type, SourceTransformer.DEFAULT);
     }
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -905,6 +905,11 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
         return null;
     }
 
+    @Override
+    public void registerSourceTransformer(String sourceType, SourceTransformer sourceTransformer) {
+        this.sourceTransformers.put(sourceType, sourceTransformer);
+    }
+
     private void registerDefaultSourceTransformers() {
         this.sourceTransformers.put(SourceTypes.PLAYER, new PlayerSourceTransformer(this));
         this.sourceTransformers.put(SourceTypes.PASSWORD, new PasswordSourceTransformer());

--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -928,4 +928,13 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
             return List.of();
         }
     }
+
+    public String unTransformSource(Source source, CommandSender sender) {
+        final SourceTransformer transformer = this.sourceTransformers.get(source.getType());
+        if (transformer != null) {
+            return transformer.unTransformIdentifier(source.getIdentifier(), sender);
+        } else {
+            return source.getIdentifier();
+        }
+    }
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminTrustCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminTrustCommand.java
@@ -73,7 +73,7 @@ public class AdminTrustCommand extends TrustCommand {
         }
         arguments.next();
         if (arguments.remaining() == 0) {
-            return plugin.completeSource(sourceType, sender);
+            return plugin.getSourceTransformer(sourceType).completions(sender);
         }
         arguments.next();
         if (arguments.remaining() == 0) {

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminTrustCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminTrustCommand.java
@@ -9,7 +9,6 @@ import org.popcraft.bolt.access.Access;
 import org.popcraft.bolt.command.Arguments;
 import org.popcraft.bolt.lang.Translation;
 import org.popcraft.bolt.source.SourceType;
-import org.popcraft.bolt.source.SourceTypes;
 import org.popcraft.bolt.util.BoltComponents;
 import org.popcraft.bolt.util.Profiles;
 import org.popcraft.bolt.util.SchedulerUtil;
@@ -74,13 +73,7 @@ public class AdminTrustCommand extends TrustCommand {
         }
         arguments.next();
         if (arguments.remaining() == 0) {
-            if (SourceTypes.PLAYER.equals(sourceType)) {
-                return plugin.getServer().getOnlinePlayers().stream().map(Player::getName).toList();
-            } else if (SourceTypes.GROUP.equals(sourceType) && sender instanceof final Player player) {
-                return plugin.getPlayersOwnedGroups(player);
-            } else {
-                return Collections.emptyList();
-            }
+            return plugin.completeSource(sourceType, sender);
         }
         arguments.next();
         if (arguments.remaining() == 0) {

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
@@ -87,7 +87,7 @@ public class ModifyCommand extends BoltCommand {
             sourceTransformer.transformIdentifier(identifier)
                     .thenAccept(id -> SchedulerUtil.schedule(plugin, player, () -> {
                         if (id == null) {
-                            sourceTransformer.errorNotFound(identifier, player);
+                            sourceTransformer.sendErrorNotFound(identifier, player);
                         } else {
                             boltPlayer.getModifications().put(Source.of(sourceType.name(), id), access.type());
                         }

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
@@ -84,10 +84,9 @@ public class ModifyCommand extends BoltCommand {
         for (final String identifier : identifiers) {
             plugin.getSourceTransformer(sourceType.name())
                     .transformIdentifier(identifier, player)
-                    .thenApply(id -> Source.of(sourceType.name(), id))
-                    .thenAccept(source -> SchedulerUtil.schedule(plugin, player, () -> {
-                        if (source != null) {
-                            boltPlayer.getModifications().put(source, access.type());
+                    .thenAccept(id -> SchedulerUtil.schedule(plugin, player, () -> {
+                        if (id != null) {
+                            boltPlayer.getModifications().put(Source.of(sourceType.name(), id), access.type());
                         }
                     }));
         }

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
@@ -9,13 +9,10 @@ import org.popcraft.bolt.access.Access;
 import org.popcraft.bolt.command.Arguments;
 import org.popcraft.bolt.command.BoltCommand;
 import org.popcraft.bolt.lang.Translation;
-import org.popcraft.bolt.source.Source;
 import org.popcraft.bolt.source.SourceType;
-import org.popcraft.bolt.source.SourceTypes;
 import org.popcraft.bolt.util.Action;
 import org.popcraft.bolt.util.BoltComponents;
 import org.popcraft.bolt.util.BoltPlayer;
-import org.popcraft.bolt.util.Profiles;
 import org.popcraft.bolt.util.SchedulerUtil;
 
 import java.util.ArrayList;
@@ -23,7 +20,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 public class ModifyCommand extends BoltCommand {
     public ModifyCommand(BoltPlugin plugin) {
@@ -85,26 +81,7 @@ public class ModifyCommand extends BoltCommand {
         }
         boltPlayer.setAction(new Action(Action.Type.EDIT, "bolt.command.edit", Boolean.toString(adding)));
         for (final String identifier : identifiers) {
-            final CompletableFuture<Source> editFuture;
-            if (SourceTypes.PLAYER.equals(sourceType.name())) {
-                editFuture = Profiles.findOrLookupProfileByName(identifier).thenApply(profile -> {
-                    if (profile.uuid() != null) {
-                        return Source.player(profile.uuid());
-                    } else {
-                        SchedulerUtil.schedule(plugin, player, () -> BoltComponents.sendMessage(
-                                player,
-                                Translation.PLAYER_NOT_FOUND,
-                                Placeholder.component(Translation.Placeholder.PLAYER, Component.text(identifier))
-                        ));
-                        return null;
-                    }
-                });
-            } else if (SourceTypes.PASSWORD.equals(sourceType.name())) {
-                editFuture = CompletableFuture.completedFuture(Source.password(identifier));
-            } else {
-                editFuture = CompletableFuture.completedFuture(Source.of(sourceType.name(), identifier));
-            }
-            editFuture.thenAccept(source -> SchedulerUtil.schedule(plugin, player, () -> {
+            plugin.transformSource(sourceType.name(), identifier, player).thenAccept(source -> SchedulerUtil.schedule(plugin, player, () -> {
                 if (source != null) {
                     boltPlayer.getModifications().put(source, access.type());
                 }
@@ -146,12 +123,7 @@ public class ModifyCommand extends BoltCommand {
         while ((added = arguments.next()) != null) {
             alreadyAdded.add(added);
         }
-        if (SourceTypes.PLAYER.equals(sourceType)) {
-            return plugin.getServer().getOnlinePlayers().stream().map(Player::getName).filter(name -> !alreadyAdded.contains(name)).toList();
-        } else if (SourceTypes.GROUP.equals(sourceType) && sender instanceof final Player player) {
-            return plugin.getPlayersOwnedGroups(player).stream().filter(name -> !alreadyAdded.contains(name)).toList();
-        }
-        return Collections.emptyList();
+        return plugin.completeSource(sourceType, sender).stream().filter(name -> !alreadyAdded.contains(name)).toList();
     }
 
     @Override

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/ModifyCommand.java
@@ -10,6 +10,7 @@ import org.popcraft.bolt.command.Arguments;
 import org.popcraft.bolt.command.BoltCommand;
 import org.popcraft.bolt.lang.Translation;
 import org.popcraft.bolt.source.Source;
+import org.popcraft.bolt.source.SourceTransformer;
 import org.popcraft.bolt.source.SourceType;
 import org.popcraft.bolt.util.Action;
 import org.popcraft.bolt.util.BoltComponents;
@@ -82,10 +83,12 @@ public class ModifyCommand extends BoltCommand {
         }
         boltPlayer.setAction(new Action(Action.Type.EDIT, "bolt.command.edit", Boolean.toString(adding)));
         for (final String identifier : identifiers) {
-            plugin.getSourceTransformer(sourceType.name())
-                    .transformIdentifier(identifier, player)
+            final SourceTransformer sourceTransformer = plugin.getSourceTransformer(sourceType.name());
+            sourceTransformer.transformIdentifier(identifier)
                     .thenAccept(id -> SchedulerUtil.schedule(plugin, player, () -> {
-                        if (id != null) {
+                        if (id == null) {
+                            sourceTransformer.errorNotFound(identifier, player);
+                        } else {
                             boltPlayer.getModifications().put(Source.of(sourceType.name(), id), access.type());
                         }
                     }));

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/TrustCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/TrustCommand.java
@@ -64,7 +64,7 @@ public class TrustCommand extends BoltCommand {
         sourceTransformer.transformIdentifier(sourceIdentifier)
                 .thenAccept(id -> SchedulerUtil.schedule(plugin, sender, () -> {
                     if (id == null) {
-                        sourceTransformer.errorNotFound(sourceIdentifier, sender);
+                        sourceTransformer.sendErrorNotFound(sourceIdentifier, sender);
                     } else {
                         final Source source = Source.of(sourceType.name(), id);
                         if (adding) {

--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/TrustCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/TrustCommand.java
@@ -61,9 +61,9 @@ public class TrustCommand extends BoltCommand {
         final AccessList accessList = Objects.requireNonNullElse(plugin.getBolt().getStore().loadAccessList(uuid).join(), new AccessList(uuid, new HashMap<>()));
         plugin.getSourceTransformer(sourceType.name())
                 .transformIdentifier(sourceIdentifier, sender)
-                .thenApply(id -> Source.of(sourceType.name(), id))
-                .thenAccept(source -> SchedulerUtil.schedule(plugin, sender, () -> {
-                    if (source != null) {
+                .thenAccept(id -> SchedulerUtil.schedule(plugin, sender, () -> {
+                    if (id != null) {
+                        final Source source = Source.of(sourceType.name(), id);
                         if (adding) {
                             accessList.getAccess().put(source.toString(), access.type());
                         } else {

--- a/bukkit/src/main/java/org/popcraft/bolt/data/migration/lwc/LWCMigration.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/data/migration/lwc/LWCMigration.java
@@ -183,7 +183,7 @@ public class LWCMigration {
                         }
 
                         if (sourceType != null) {
-                            final String sourceIdentifier = plugin.getSourceTransformer(sourceType).transformIdentifier(identifier, plugin.getServer().getConsoleSender()).join();
+                            final String sourceIdentifier = plugin.getSourceTransformer(sourceType).transformIdentifier(identifier).join();
                             if (sourceIdentifier != null) {
                                 access.put(Source.of(sourceType, sourceIdentifier).toString(), accessType);
                             }

--- a/bukkit/src/main/java/org/popcraft/bolt/data/migration/lwc/LWCMigration.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/data/migration/lwc/LWCMigration.java
@@ -165,20 +165,28 @@ public class LWCMigration {
                 if (dataRights != null) {
                     for (DataRights rights : data.getRights()) {
                         final String accessType = rights.getRights() == Permission.Access.ADMIN.ordinal() ? defaultAccessAdmin : defaultAccessNormal;
+                        final String sourceType;
+                        String identifier = rights.getName();
                         if (rights.getType() == Permission.Type.GROUP.ordinal()) {
-                            access.put(Source.of(SourceTypes.PERMISSION, "group.%s".formatted(rights.getName())).toString(), accessType);
+                            sourceType = SourceTypes.PERMISSION;
+                            identifier = "group.%s".formatted(identifier);
                         } else if (rights.getType() == Permission.Type.PLAYER.ordinal()) {
-                            final UUID uuid = Optional.ofNullable(Profiles.findProfileByName(rights.getName()).uuid())
-                                    .orElseGet(() -> Profiles.lookupProfileByName(rights.getName()).join().uuid());
-                            if (uuid != null) {
-                                access.put(Source.player(uuid).toString(), accessType);
-                            }
+                            sourceType = SourceTypes.PLAYER;
                         } else if (rights.getType() == Permission.Type.TOWN.ordinal()) {
-                            access.put(Source.of(SourceTypes.TOWN, rights.getName()).toString(), accessType);
+                            sourceType = SourceTypes.TOWN;
                         } else if (rights.getType() == Permission.Type.REGION.ordinal()) {
-                            access.put(Source.of(SourceTypes.REGION, rights.getName()).toString(), accessType);
+                            sourceType = SourceTypes.REGION;
                         } else if (rights.getType() == Permission.Type.FACTION.ordinal()) {
-                            access.put(Source.of(SourceTypes.FACTION, rights.getName()).toString(), accessType);
+                            sourceType = SourceTypes.FACTION;
+                        } else {
+                            sourceType = null;
+                        }
+
+                        if (sourceType != null) {
+                            final String sourceIdentifier = plugin.getSourceTransformer(sourceType).transformIdentifier(identifier, plugin.getServer().getConsoleSender()).join();
+                            if (sourceIdentifier != null) {
+                                access.put(Source.of(sourceType, sourceIdentifier).toString(), accessType);
+                            }
                         }
                     }
                 }

--- a/bukkit/src/main/java/org/popcraft/bolt/source/GroupSourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/GroupSourceTransformer.java
@@ -1,0 +1,23 @@
+package org.popcraft.bolt.source;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.popcraft.bolt.BoltPlugin;
+
+import java.util.List;
+
+public class GroupSourceTransformer implements SourceTransformer {
+    private final BoltPlugin plugin;
+
+    public GroupSourceTransformer(final BoltPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public List<String> completions(CommandSender sender) {
+        if (sender instanceof final Player player) {
+            return plugin.getPlayersOwnedGroups(player);
+        }
+        return List.of();
+    }
+}

--- a/bukkit/src/main/java/org/popcraft/bolt/source/PasswordSourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/PasswordSourceTransformer.java
@@ -1,27 +1,16 @@
 package org.popcraft.bolt.source;
 
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
-import org.bukkit.command.CommandSender;
-import org.popcraft.bolt.BoltPlugin;
-import org.popcraft.bolt.lang.Translation;
-import org.popcraft.bolt.util.BoltComponents;
-import org.popcraft.bolt.util.Profiles;
-import org.popcraft.bolt.util.SchedulerUtil;
-
-import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public class PasswordSourceTransformer implements SourceTransformer {
     @Override
-    public CompletableFuture<String> transformIdentifier(String identifier, CommandSender sender) {
+    public CompletableFuture<String> transformIdentifier(String identifier) {
         final Source password = Source.password(identifier);
         return CompletableFuture.completedFuture(password != null ? password.getIdentifier() : null);
     }
 
     @Override
-    public String unTransformIdentifier(String identifier, CommandSender sender) {
+    public String unTransformIdentifier(String identifier) {
         return "Password";
     }
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/source/PasswordSourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/PasswordSourceTransformer.java
@@ -1,0 +1,20 @@
+package org.popcraft.bolt.source;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.command.CommandSender;
+import org.popcraft.bolt.BoltPlugin;
+import org.popcraft.bolt.lang.Translation;
+import org.popcraft.bolt.util.BoltComponents;
+import org.popcraft.bolt.util.Profiles;
+import org.popcraft.bolt.util.SchedulerUtil;
+
+import java.util.concurrent.CompletableFuture;
+
+public class PasswordSourceTransformer implements SourceTransformer {
+    @Override
+    public CompletableFuture<String> transformIdentifier(String identifier, CommandSender sender) {
+        final Source password = Source.password(identifier);
+        return CompletableFuture.completedFuture(password != null ? password.getIdentifier() : null);
+    }
+}

--- a/bukkit/src/main/java/org/popcraft/bolt/source/PasswordSourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/PasswordSourceTransformer.java
@@ -9,6 +9,8 @@ import org.popcraft.bolt.util.BoltComponents;
 import org.popcraft.bolt.util.Profiles;
 import org.popcraft.bolt.util.SchedulerUtil;
 
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public class PasswordSourceTransformer implements SourceTransformer {
@@ -16,5 +18,10 @@ public class PasswordSourceTransformer implements SourceTransformer {
     public CompletableFuture<String> transformIdentifier(String identifier, CommandSender sender) {
         final Source password = Source.password(identifier);
         return CompletableFuture.completedFuture(password != null ? password.getIdentifier() : null);
+    }
+
+    @Override
+    public String unTransformIdentifier(String identifier, CommandSender sender) {
+        return "Password";
     }
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/source/PlayerSourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/PlayerSourceTransformer.java
@@ -8,7 +8,6 @@ import org.popcraft.bolt.BoltPlugin;
 import org.popcraft.bolt.lang.Translation;
 import org.popcraft.bolt.util.BoltComponents;
 import org.popcraft.bolt.util.Profiles;
-import org.popcraft.bolt.util.SchedulerUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,19 +23,22 @@ public class PlayerSourceTransformer implements SourceTransformer {
     }
 
     @Override
-    public CompletableFuture<String> transformIdentifier(String identifier, CommandSender sender) {
+    public CompletableFuture<String> transformIdentifier(String identifier) {
         return Profiles.findOrLookupProfileByName(identifier).thenApply(profile -> {
             if (profile.uuid() != null) {
                 return profile.uuid().toString();
-            } else {
-                SchedulerUtil.schedule(plugin, sender, () -> BoltComponents.sendMessage(
-                        sender,
-                        Translation.PLAYER_NOT_FOUND,
-                        Placeholder.component(Translation.Placeholder.PLAYER, Component.text(identifier))
-                ));
-                return null;
             }
+            return null;
         });
+    }
+
+    @Override
+    public void errorNotFound(String identifier, CommandSender sender) {
+        BoltComponents.sendMessage(
+                sender,
+                Translation.PLAYER_NOT_FOUND,
+                Placeholder.component(Translation.Placeholder.PLAYER, Component.text(identifier))
+        );
     }
 
     @Override
@@ -49,7 +51,7 @@ public class PlayerSourceTransformer implements SourceTransformer {
     }
 
     @Override
-    public String unTransformIdentifier(String identifier, CommandSender sender) {
+    public String unTransformIdentifier(String identifier) {
         final UUID uuid = UUID.fromString(identifier);
         final String playerName = Profiles.findProfileByUniqueId(uuid).name();
         return Optional.ofNullable(playerName).orElse(identifier);

--- a/bukkit/src/main/java/org/popcraft/bolt/source/PlayerSourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/PlayerSourceTransformer.java
@@ -1,0 +1,48 @@
+package org.popcraft.bolt.source;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.popcraft.bolt.BoltPlugin;
+import org.popcraft.bolt.lang.Translation;
+import org.popcraft.bolt.util.BoltComponents;
+import org.popcraft.bolt.util.Profiles;
+import org.popcraft.bolt.util.SchedulerUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class PlayerSourceTransformer implements SourceTransformer {
+    private final BoltPlugin plugin;
+
+    public PlayerSourceTransformer(final BoltPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public CompletableFuture<String> transformIdentifier(String identifier, CommandSender sender) {
+        return Profiles.findOrLookupProfileByName(identifier).thenApply(profile -> {
+            if (profile.uuid() != null) {
+                return profile.uuid().toString();
+            } else {
+                SchedulerUtil.schedule(plugin, sender, () -> BoltComponents.sendMessage(
+                        sender,
+                        Translation.PLAYER_NOT_FOUND,
+                        Placeholder.component(Translation.Placeholder.PLAYER, Component.text(identifier))
+                ));
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public List<String> completions(CommandSender sender) {
+        List<String> list = new ArrayList<>();
+        for (Player player : plugin.getServer().getOnlinePlayers()) {
+            list.add(player.getName());
+        }
+        return list;
+    }
+}

--- a/bukkit/src/main/java/org/popcraft/bolt/source/PlayerSourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/PlayerSourceTransformer.java
@@ -33,7 +33,7 @@ public class PlayerSourceTransformer implements SourceTransformer {
     }
 
     @Override
-    public void errorNotFound(String identifier, CommandSender sender) {
+    public void sendErrorNotFound(String identifier, CommandSender sender) {
         BoltComponents.sendMessage(
                 sender,
                 Translation.PLAYER_NOT_FOUND,

--- a/bukkit/src/main/java/org/popcraft/bolt/source/PlayerSourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/PlayerSourceTransformer.java
@@ -12,6 +12,8 @@ import org.popcraft.bolt.util.SchedulerUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public class PlayerSourceTransformer implements SourceTransformer {
@@ -44,5 +46,12 @@ public class PlayerSourceTransformer implements SourceTransformer {
             list.add(player.getName());
         }
         return list;
+    }
+
+    @Override
+    public String unTransformIdentifier(String identifier, CommandSender sender) {
+        final UUID uuid = UUID.fromString(identifier);
+        final String playerName = Profiles.findProfileByUniqueId(uuid).name();
+        return Optional.ofNullable(playerName).orElse(identifier);
     }
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
@@ -5,19 +5,47 @@ import org.bukkit.command.CommandSender;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Allows for certain source types to be stored differently from how the user interacts with them through commands.
+ * For example, a player source can be stored using the player's UUID, but the user can use usernames in commands, and
+ * have usernames displayed to them.
+ * <p>
+ * Also allows for providing TAB completion suggestions. For example, a player source can suggest the name of currently
+ * online players.
+ */
 public interface SourceTransformer {
+    /**
+     * Converts a user's input into the stored format
+     * @param identifier user input
+     * @param sender the user making the input. This may be used to send error messages in case of invalid format.
+     * @return identifier to store in a future. The future may contain {@code null} if an invalid input was given.
+     */
     default CompletableFuture<String> transformIdentifier(String identifier, CommandSender sender) {
         return CompletableFuture.completedFuture(identifier);
     }
 
+    /**
+     * TAB completion suggestions for this source type.
+     * @param sender the user making the input
+     * @return list of TAB completions
+     */
     default List<String> completions(CommandSender sender) {
         return List.of();
     }
 
+    /**
+     * Converts a stored identifier back into what should be displayed to the user.
+     * @param identifier stored format
+     * @param sender user to display to
+     * @return what to display
+     */
     default String unTransformIdentifier(String identifier, CommandSender sender) {
         return identifier;
     }
 
+    /**
+     * A source transformer that makes no changes and provides no suggestions.
+     */
     SourceTransformer DEFAULT = new SourceTransformer() {
     };
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
@@ -13,4 +13,8 @@ public interface SourceTransformer {
     default List<String> completions(CommandSender sender) {
         return List.of();
     }
+
+    default String unTransformIdentifier(String identifier, CommandSender sender) {
+        return identifier;
+    }
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
@@ -35,7 +35,7 @@ public interface SourceTransformer {
      * @param identifier user input which failed to be transformed.
      * @param sender     the sender to provide feedback to
      */
-    default void errorNotFound(String identifier, CommandSender sender) {
+    default void sendErrorNotFound(String identifier, CommandSender sender) {
         BoltComponents.sendMessage(
                 sender,
                 Translation.GENERIC_NOT_FOUND,

--- a/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
@@ -1,0 +1,16 @@
+package org.popcraft.bolt.source;
+
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface SourceTransformer {
+    default CompletableFuture<String> transformIdentifier(String identifier, CommandSender sender) {
+        return CompletableFuture.completedFuture(identifier);
+    }
+
+    default List<String> completions(CommandSender sender) {
+        return List.of();
+    }
+}

--- a/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
@@ -17,4 +17,7 @@ public interface SourceTransformer {
     default String unTransformIdentifier(String identifier, CommandSender sender) {
         return identifier;
     }
+
+    SourceTransformer DEFAULT = new SourceTransformer() {
+    };
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/source/SourceTransformer.java
@@ -1,6 +1,10 @@
 package org.popcraft.bolt.source;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.command.CommandSender;
+import org.popcraft.bolt.lang.Translation;
+import org.popcraft.bolt.util.BoltComponents;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -16,16 +20,32 @@ import java.util.concurrent.CompletableFuture;
 public interface SourceTransformer {
     /**
      * Converts a user's input into the stored format
+     *
      * @param identifier user input
-     * @param sender the user making the input. This may be used to send error messages in case of invalid format.
      * @return identifier to store in a future. The future may contain {@code null} if an invalid input was given.
      */
-    default CompletableFuture<String> transformIdentifier(String identifier, CommandSender sender) {
+    default CompletableFuture<String> transformIdentifier(String identifier) {
         return CompletableFuture.completedFuture(identifier);
     }
 
     /**
+     * Reports an error to the sender. This may be called by a command when {@link #transformIdentifier(String)} returns
+     * {@code null}.
+     *
+     * @param identifier user input which failed to be transformed.
+     * @param sender     the sender to provide feedback to
+     */
+    default void errorNotFound(String identifier, CommandSender sender) {
+        BoltComponents.sendMessage(
+                sender,
+                Translation.GENERIC_NOT_FOUND,
+                Placeholder.component(Translation.Placeholder.X, Component.text(identifier))
+        );
+    }
+
+    /**
      * TAB completion suggestions for this source type.
+     *
      * @param sender the user making the input
      * @return list of TAB completions
      */
@@ -35,11 +55,11 @@ public interface SourceTransformer {
 
     /**
      * Converts a stored identifier back into what should be displayed to the user.
+     *
      * @param identifier stored format
-     * @param sender user to display to
      * @return what to display
      */
-    default String unTransformIdentifier(String identifier, CommandSender sender) {
+    default String unTransformIdentifier(String identifier) {
         return identifier;
     }
 

--- a/bukkit/src/main/java/org/popcraft/bolt/util/Protections.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Protections.java
@@ -19,14 +19,11 @@ import org.popcraft.bolt.protection.BlockProtection;
 import org.popcraft.bolt.protection.EntityProtection;
 import org.popcraft.bolt.protection.Protection;
 import org.popcraft.bolt.source.Source;
-import org.popcraft.bolt.source.SourceTypes;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
 
 import static org.popcraft.bolt.lang.Translator.isTranslatable;
 import static org.popcraft.bolt.util.BoltComponents.getLocaleOf;
@@ -139,7 +136,7 @@ public final class Protections {
             if (source.getType().equals(source.getIdentifier())) {
                 subject = Strings.toTitleCase(source.getType());
             } else {
-                subject = plugin.getSourceTransformer(source.getType()).unTransformIdentifier(source.getIdentifier(), sender);
+                subject = plugin.getSourceTransformer(source.getType()).unTransformIdentifier(source.getIdentifier());
             }
             if (plugin.getDefaultAccessType().equals(access)) {
                 list.add(resolveTranslation(

--- a/bukkit/src/main/java/org/popcraft/bolt/util/Protections.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Protections.java
@@ -139,7 +139,7 @@ public final class Protections {
             if (source.getType().equals(source.getIdentifier())) {
                 subject = Strings.toTitleCase(source.getType());
             } else {
-                subject = plugin.unTransformSource(source, sender);
+                subject = plugin.getSourceTransformer(source.getType()).unTransformIdentifier(source.getIdentifier(), sender);
             }
             if (plugin.getDefaultAccessType().equals(access)) {
                 list.add(resolveTranslation(

--- a/bukkit/src/main/java/org/popcraft/bolt/util/Protections.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Protections.java
@@ -134,18 +134,13 @@ public final class Protections {
             final String entry = accessEntry.getKey();
             final String access = accessEntry.getValue();
             final Source source = Source.parse(entry);
+            final BoltPlugin plugin = JavaPlugin.getPlugin(BoltPlugin.class);
             final String subject;
-            if (SourceTypes.PLAYER.equals(source.getType())) {
-                final String playerUuid = source.getIdentifier();
-                final UUID uuid = UUID.fromString(playerUuid);
-                final String playerName = Profiles.findProfileByUniqueId(uuid).name();
-                subject = Optional.ofNullable(playerName).orElse(playerUuid);
-            } else if (SourceTypes.PASSWORD.equals(source.getType()) || source.getType().equals(source.getIdentifier())) {
+            if (source.getType().equals(source.getIdentifier())) {
                 subject = Strings.toTitleCase(source.getType());
             } else {
-                subject = source.getIdentifier();
+                subject = plugin.unTransformSource(source, sender);
             }
-            final BoltPlugin plugin = JavaPlugin.getPlugin(BoltPlugin.class);
             if (plugin.getDefaultAccessType().equals(access)) {
                 list.add(resolveTranslation(
                         Translation.ACCESS_LIST_ENTRY_DEFAULT,

--- a/common/src/main/java/org/popcraft/bolt/lang/Translation.java
+++ b/common/src/main/java/org/popcraft/bolt/lang/Translation.java
@@ -51,6 +51,7 @@ public class Translation {
     public static final String FIND_NEXT_NEW_PAGE_SEPARATOR = "find_next_new_page_separator";
     public static final String FIND_NONE = "find_none";
     public static final String FLUSH = "flush";
+    public static final String GENERIC_NOT_FOUND = "generic_not_found";
     public static final String GROUP_ALREADY_EXISTS = "group_already_exists";
     public static final String GROUP_CREATED = "group_created";
     public static final String GROUP_DELETED = "group_deleted";

--- a/common/src/main/resources/lang/en.properties
+++ b/common/src/main/resources/lang/en.properties
@@ -48,6 +48,7 @@ find_next_new_page_other=<white> <page> </white>
 find_next_new_page_separator=|
 find_none=None
 flush=Flushing protection updates (<count>)
+generic_not_found=<red>Cannot find <yellow><x></yellow>.</red>
 group_already_exists=The group <yellow><group></yellow> already exists!
 group_created=Created group <yellow><group></yellow>.
 group_deleted=Deleted group <yellow><group></yellow>.


### PR DESCRIPTION
Reduces code duplication and increases what's possible with the API

- [x] Untransform (Protections.accessList)
- [x] Command uses
- [x] Migration uses
- [x] Expose in API
- [ ] Think about pop4959/BoltTowny#2