### PR TITLE
Fix invalid report data

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/util/Metrics.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Metrics.java
@@ -28,10 +28,10 @@ public final class Metrics {
             final StackTraceElement stackTraceElement = stackTrace[i];
             if (stackTraceElement.getClassName().startsWith(DATA_PACKAGE)) {
                 final String type = stackTraceElement.getMethodName();
-                for (int j = i + 1; j < stackTrace.length - 1; ++j) {
-                    final StackTraceElement nextStackTraceElement = stackTrace[j + 1];
-                    if (!nextStackTraceElement.getClassName().startsWith(REVERSE_DOMAIN)) {
-                        final String consumer = stackTrace[j].getMethodName();
+                for (int j = stackTrace.length - 1; j > i; --j) {
+                    final StackTraceElement revStackTraceElement = stackTrace[j];
+                    if (revStackTraceElement.getClassName().startsWith(REVERSE_DOMAIN)) {
+                        final String consumer = revStackTraceElement.getMethodName();
                         final ProtectionAccess protectionAccess = new ProtectionAccess(type, consumer);
                         protectionAccessCounts.put(protectionAccess, protectionAccessCounts.getOrDefault(protectionAccess, 0L) + 1);
                         return;


### PR DESCRIPTION
The metrics data from `/bolt admin report` uses a simple stack walking algorithm that sometimes gives the wrong result.

Here's an example stack trace for a correctly recorded protection access

    java.lang.Thread.getStackTrace(Thread.java:2450)
    org.popcraft.bolt.util.Metrics.recordProtectionAccess(Metrics.java:27)
    org.popcraft.bolt.data.SimpleProtectionCache.loadBlockProtection(SimpleProtectionCache.java:43)
    org.popcraft.bolt.BoltPlugin.loadProtection(BoltPlugin.java:673)
    org.popcraft.bolt.BoltPlugin.findProtection(BoltPlugin.java:702)
    org.popcraft.bolt.listeners.BlockListener.onPlayerInteract(BlockListener.java:98)
    co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80)
    org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70)
    ... 22 stack frame entries removed for brevity ...

Bolt identifies the first stack frame from the top belonging to the package `org.popcraft.bolt.data`, finding the third line, and stores it as the "type", in this case `loadBlockProtection`. Then, it looks down until it finds a line *not* in the `org.popcraft` package, finding the seventh line, and stores the line immediately before that one as the "consumer", in this case `onPlayerInteract`.

However, consider the following case:

    java.lang.Thread.getStackTrace(Thread.java:2450)
    org.popcraft.bolt.util.Metrics.recordProtectionAccess(Metrics.java:27)
    org.popcraft.bolt.data.SimpleProtectionCache.loadBlockProtection(SimpleProtectionCache.java:43)
    org.popcraft.bolt.BoltPlugin.loadProtection(BoltPlugin.java:673)
    org.popcraft.bolt.BoltPlugin.findProtection(BoltPlugin.java:702)
    org.popcraft.bolt.BoltPlugin.isProtected(BoltPlugin.java:632)
    it.unimi.dsi.fastutil.objects.ObjectArrayList.removeIf(ObjectArrayList.java:804)
    org.popcraft.bolt.listeners.BlockListener.onEntityExplode(BlockListener.java:362)
    co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80)
    org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70)
    ... 27 stack frame entries removed for brevity ...

In this case, the "type" is correctly, but the "consumer" will be erroneously set to `isProtected`, due to the intervening `removeIf` call in a different package. This means that `/bolt admin report` will only give you `isProtected`, providing no valuable info about the event in which this check took place in.

This commit changes the algorithm to instead look for the "consumer" starting from the bottom of the stack trace, finding the first entry belonging to the `org.popcraft` package from the bottom.

With this patch, the "consumer" is correctly set to `onEntityExplode` for the second case.