### PR TITLE
Fix placing block when opening iron door

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/util/Doors.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Doors.java
@@ -57,6 +57,8 @@ public final class Doors {
         final Set<Block> doors = new HashSet<>();
         if (!isDoorOpenableNormally(block)) {
             doors.add(block);
+            event.setUseItemInHand(Event.Result.DENY);
+            event.setUseInteractedBlock(Event.Result.ALLOW);
         }
         if (plugin.isDoorsOpenDouble()) {
             final Block hingedBlock = getHingedBlock(block);


### PR DESCRIPTION
Interacting with an iron door with open-iron enabled, while also having a block in your hand, both places the block and opens the door. This makes it so only the door is opened. The block still visually appears for an instant due to client prediction but disappears immediately after.