### PR TITLE
Better handling of bucket emptying and filling

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -413,17 +413,33 @@ public final class BlockListener extends InteractionListener implements Listener
 
     @EventHandler
     public void onPlayerBucketEmpty(final PlayerBucketEmptyEvent e) {
+        final Protection protection = plugin.findProtection(e.getBlock());
+        if (protection == null) {
+            return;
+        }
         final Player player = e.getPlayer();
-        if (!plugin.canAccess(e.getBlockClicked(), player, Permission.INTERACT) || !plugin.canAccess(e.getBlock(), player, Permission.DESTROY)) {
+        if (e.getBlock().equals(e.getBlockClicked()) && Tag.CAULDRONS.isTagged(e.getBlock().getType())) {
+            if (!plugin.canAccess(e.getBlock(), player, Permission.INTERACT, Permission.DEPOSIT)) {
+                e.setCancelled(true);
+            }
+        } else if (!e.getBlock().equals(e.getBlockClicked())) {
+            // Prevent accidental deletion of protected blocks by them getting replaced.
+            // Purposefully not checking for destroy permissions, that logic is for BlockBreakEvent.
             e.setCancelled(true);
         }
     }
 
     @EventHandler
     public void onPlayerBucketFill(final PlayerBucketFillEvent e) {
+        final Protection protection = plugin.findProtection(e.getBlock());
+        if (protection == null) {
+            return;
+        }
         final Player player = e.getPlayer();
-        if (!plugin.canAccess(e.getBlockClicked(), player, Permission.INTERACT) || !plugin.canAccess(e.getBlock(), player, Permission.DESTROY)) {
-            e.setCancelled(true);
+        if (e.getBlock().equals(e.getBlockClicked()) && Tag.CAULDRONS.isTagged(e.getBlock().getType())) {
+            if (!plugin.canAccess(e.getBlock(), player, Permission.INTERACT, Permission.WITHDRAW)) {
+                e.setCancelled(true);
+            }
         }
     }
 

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -419,7 +419,7 @@ public final class BlockListener extends InteractionListener implements Listener
         }
         final Player player = e.getPlayer();
         if (e.getBlock().equals(e.getBlockClicked()) && Tag.CAULDRONS.isTagged(e.getBlock().getType())) {
-            if (!plugin.canAccess(e.getBlock(), player, Permission.INTERACT, Permission.DEPOSIT)) {
+            if (!plugin.canAccess(protection, player, Permission.INTERACT, Permission.DEPOSIT)) {
                 e.setCancelled(true);
             }
         } else if (!e.getBlock().equals(e.getBlockClicked())) {
@@ -437,7 +437,7 @@ public final class BlockListener extends InteractionListener implements Listener
         }
         final Player player = e.getPlayer();
         if (e.getBlock().equals(e.getBlockClicked()) && Tag.CAULDRONS.isTagged(e.getBlock().getType())) {
-            if (!plugin.canAccess(e.getBlock(), player, Permission.INTERACT, Permission.WITHDRAW)) {
+            if (!plugin.canAccess(protection, player, Permission.INTERACT, Permission.WITHDRAW)) {
                 e.setCancelled(true);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/pop4959/Bolt/issues/202

Explicitly handles cauldrons and no longer acts like every bucket empty or fill is destructive

Note: filling or emptying a cauldron causes desyncs since it changes the block type. This is a future issue.

Note: Forbids waterlogging a block "indirectly". This wasn't possible before anyway but it technically could be safely allowed with extra logic.