### PR TITLE
Fix modifying blocks always being cancelled

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -203,10 +203,19 @@ public final class BlockListener extends InteractionListener implements Listener
         }
         final Block block = replaced.getBlock();
         final Protection protection = plugin.findProtection(block);
-        if (protection != null) {
+        if (protection == null) {
+            return;
+        }
+        if (Tag.REPLACEABLE.isTagged(e.getBlockReplacedState().getType())) {
             // Prevent accidental deletion of protected blocks by them getting replaced.
             // Purposefully not checking for destroy permissions, that logic is for BlockBreakEvent.
             e.setCancelled(true);
+        } else {
+            // This is, bafflingly, fired in cases like stripping a log (which *also* called EntityChangeBlockEvent)
+            // but also fired in other cases, like placing a slab on top of another.
+            if (!plugin.canAccess(block, e.getPlayer(), Permission.INTERACT)) {
+                e.setCancelled(true);
+            }
         }
     }
 


### PR DESCRIPTION
The change to prevent protected blocks being replaced (4c744070d53ef1186511a1116a0bbe56fee2be63) had unintended consequences. This is because I didn't know that modifying blocks, such as stripping a log, also fires BlockPlaceEvent, for some reason.

This patch applies the replaceable block protection code only to actually replaceable blocks. However note that Tag.REPLACEABLE isn't perfect (https://bugs.mojang.com/browse/MC-261616) but because Spigot entirely lacks `Block.isReplaceable()` it's the best we have.