### PR TITLE
Add "disable" suggestion for admin report command

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminReportCommand.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/command/impl/AdminReportCommand.java
@@ -87,6 +87,9 @@ public class AdminReportCommand extends BoltCommand {
 
     @Override
     public List<String> suggestions(CommandSender sender, Arguments arguments) {
+        if (Metrics.isEnabled()) {
+            return List.of("disable");
+        }
         return Collections.emptyList();
     }
 


### PR DESCRIPTION
It's mentioned as an option when you run the initial report command but being suggested makes it faster/easier to use. Just seemed like a small missing thing.