### PR TITLE
Fire events on autoprotect

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/event/LockBlockEvent.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/event/LockBlockEvent.java
@@ -6,10 +6,12 @@ import org.bukkit.entity.Player;
 public class LockBlockEvent extends Cancellable implements Event {
     private final Player player;
     private final Block block;
+    private final boolean autoprotect;
 
-    public LockBlockEvent(Player player, Block block) {
+    public LockBlockEvent(Player player, Block block, boolean autoprotect) {
         this.player = player;
         this.block = block;
+        this.autoprotect = autoprotect;
     }
 
     public Player getPlayer() {
@@ -18,5 +20,10 @@ public class LockBlockEvent extends Cancellable implements Event {
 
     public Block getBlock() {
         return this.block;
+    }
+
+    /** Whether this event was fired from a player placing a block with autoprotect enabled */
+    public boolean isAutoprotect() {
+        return this.autoprotect;
     }
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/event/LockEntityEvent.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/event/LockEntityEvent.java
@@ -6,10 +6,12 @@ import org.bukkit.entity.Player;
 public class LockEntityEvent extends Cancellable implements Event {
     private final Player player;
     private final Entity entity;
+    private final boolean autoprotect;
 
-    public LockEntityEvent(Player player, Entity entity) {
+    public LockEntityEvent(Player player, Entity entity, boolean autoprotect) {
         this.player = player;
         this.entity = entity;
+        this.autoprotect = autoprotect;
     }
 
     public Player getPlayer() {
@@ -18,5 +20,10 @@ public class LockEntityEvent extends Cancellable implements Event {
 
     public Entity getEntity() {
         return this.entity;
+    }
+
+    /** Whether this event was fired from a player creating an entity with autoprotect enabled */
+    public boolean isAutoprotect() {
+        return this.autoprotect;
     }
 }

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -9,7 +9,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.ChiseledBookshelf;
 import org.bukkit.block.PistonMoveReaction;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.type.Leaves;
 import org.bukkit.block.data.type.Piston;
@@ -47,6 +46,7 @@ import org.bukkit.event.world.StructureGrowEvent;
 import org.bukkit.util.Vector;
 import org.popcraft.bolt.BoltPlugin;
 import org.popcraft.bolt.access.Access;
+import org.popcraft.bolt.event.LockBlockEvent;
 import org.popcraft.bolt.lang.Translation;
 import org.popcraft.bolt.matcher.Match;
 import org.popcraft.bolt.protection.BlockProtection;
@@ -244,6 +244,11 @@ public final class BlockListener extends InteractionListener implements Listener
             return;
         }
         if (plugin.isProtected(block)) {
+            return;
+        }
+        final LockBlockEvent event = new LockBlockEvent(player, block, true);
+        plugin.getEventBus().post(event);
+        if (event.isCancelled()) {
             return;
         }
         final BlockProtection newProtection = plugin.createProtection(block, player.getUniqueId(), access.type());

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -53,6 +53,7 @@ import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.popcraft.bolt.BoltPlugin;
 import org.popcraft.bolt.access.Access;
+import org.popcraft.bolt.event.LockEntityEvent;
 import org.popcraft.bolt.lang.Translation;
 import org.popcraft.bolt.protection.BlockProtection;
 import org.popcraft.bolt.protection.EntityProtection;
@@ -153,6 +154,11 @@ public final class EntityListener extends InteractionListener implements Listene
             return;
         }
         if (access.restricted() && !player.hasPermission("bolt.type.protection.%s".formatted(access.type()))) {
+            return;
+        }
+        final LockEntityEvent event = new LockEntityEvent(player, entity, true);
+        plugin.getEventBus().post(event);
+        if (event.isCancelled()) {
             return;
         }
         final EntityProtection newProtection = plugin.createProtection(entity, player.getUniqueId(), access.type());

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/InteractionListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/InteractionListener.java
@@ -66,9 +66,9 @@ abstract class InteractionListener {
             case LOCK -> {
                 final Cancellable event;
                 if (object instanceof final Block block) {
-                    event = new LockBlockEvent(player, block);
+                    event = new LockBlockEvent(player, block, false);
                 } else if (object instanceof final Entity entity) {
-                    event = new LockEntityEvent(player, entity);
+                    event = new LockEntityEvent(player, entity, false);
                 } else {
                     throw new IllegalStateException("Protection is not a block or entity");
                 }


### PR DESCRIPTION
Previously, protections weren't created for blocks locked through autoprotect, even though a lock was created. Also adds an extra field to test whether a lock event was caused by autoprotect or not.