### PR TITLE
Fix profile lookups always failing

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/util/Profiles.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Profiles.java
@@ -53,7 +53,7 @@ public final class Profiles {
         }
         final PlayerProfile playerProfile;
         try {
-            playerProfile = Bukkit.createPlayerProfile(name);
+            playerProfile = Bukkit.createPlayerProfile(NIL_UUID, name);
         } catch (final IllegalArgumentException ignored) {
             return CompletableFuture.completedFuture(SimpleProfileCache.EMPTY_PROFILE);
         }
@@ -105,7 +105,7 @@ public final class Profiles {
         }
         final PlayerProfile playerProfile;
         try {
-            playerProfile = Bukkit.createPlayerProfile(uuid);
+            playerProfile = Bukkit.createPlayerProfile(uuid, "");
         } catch (final IllegalArgumentException ignored) {
             return CompletableFuture.completedFuture(SimpleProfileCache.EMPTY_PROFILE);
         }


### PR DESCRIPTION
It turns out that at some point, the single parameter Bukkit.createPlayerProfile methods stopped working because of Mojang changes. Spigot never fixed this and neither did Paper, because Paper has their own API for this and deprecated this one.

However, we can't use the Paper API either because it is also broken (https://github.com/PaperMC/Paper/issues/8927).

We can work around the issue by passing dummy parameters. The implementation ignores the nil uuid and empty strings specifically, so we can pass these to use the two-parameter method that doesn't inexplicably error.