### PR TITLE
Add ProtectionInteractEvent for protection name overriding in Bolt messaging

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/event/ProtectionInteractEvent.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/event/ProtectionInteractEvent.java
@@ -1,0 +1,26 @@
+package org.popcraft.bolt.event;
+
+import net.kyori.adventure.text.Component;
+import org.popcraft.bolt.protection.Protection;
+
+public class ProtectionInteractEvent implements Event {
+    private final Protection protection;
+    private Component protectionName;
+
+    public ProtectionInteractEvent(final Protection protection, final Component protectionName) {
+        this.protection = protection;
+        this.protectionName = protectionName;
+    }
+
+    public Protection getProtection() {
+        return protection;
+    }
+
+    public Component getProtectionName() {
+        return protectionName;
+    }
+
+    public void setProtectionName(final Component protectionName) {
+        this.protectionName = protectionName;
+    }
+}

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -48,6 +48,7 @@ import org.bukkit.util.Vector;
 import org.popcraft.bolt.BoltPlugin;
 import org.popcraft.bolt.access.Access;
 import org.popcraft.bolt.event.LockBlockEvent;
+import org.popcraft.bolt.event.ProtectionInteractEvent;
 import org.popcraft.bolt.lang.Translation;
 import org.popcraft.bolt.matcher.Match;
 import org.popcraft.bolt.protection.BlockProtection;
@@ -105,6 +106,8 @@ public final class BlockListener extends InteractionListener implements Listener
             SchedulerUtil.schedule(plugin, player, boltPlayer::clearInteraction);
             shouldCancel = true;
         } else if (protection != null) {
+            ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, Protections.displayType(protection, player));
+            plugin.getEventBus().post(protectionInteractEvent);
             final boolean hasNotifyPermission = player.hasPermission("bolt.protection.notify");
             final boolean canInteract = plugin.canAccess(protection, player, Permission.INTERACT);
             if (canInteract && protection instanceof final BlockProtection blockProtection) {
@@ -118,7 +121,7 @@ public final class BlockListener extends InteractionListener implements Listener
                             player,
                             Translation.LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
                     );
                 }
             }
@@ -143,7 +146,7 @@ public final class BlockListener extends InteractionListener implements Listener
                                     Translation.PROTECTION_NOTIFY_GENERIC,
                                     plugin.isUseActionBar(),
                                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
                             );
                         });
                     } else if (!isYou || player.hasPermission("bolt.protection.notify.self")) {
@@ -156,7 +159,7 @@ public final class BlockListener extends InteractionListener implements Listener
                                     Translation.PROTECTION_NOTIFY,
                                     plugin.isUseActionBar(),
                                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName()),
                                     Placeholder.component(Translation.Placeholder.PLAYER, Component.text(owner))
                             );
                         });
@@ -255,13 +258,15 @@ public final class BlockListener extends InteractionListener implements Listener
         }
         final BlockProtection newProtection = plugin.createProtection(block, player.getUniqueId(), access.type());
         plugin.saveProtection(newProtection);
+        ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(newProtection, Protections.protectionType(newProtection, player));
+        plugin.getEventBus().post(protectionInteractEvent);
         if (!plugin.player(player.getUniqueId()).hasMode(Mode.NOSPAM)) {
             BoltComponents.sendMessage(
                     player,
                     Translation.CLICK_LOCKED,
                     plugin.isUseActionBar(),
                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection, player)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(block, player))
+                    Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
             );
         }
     }
@@ -300,13 +305,15 @@ public final class BlockListener extends InteractionListener implements Listener
             }
         }
         plugin.removeProtection(protection);
+        ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, Protections.protectionType(protection, player));
+        plugin.getEventBus().post(protectionInteractEvent);
         if (!plugin.player(player.getUniqueId()).hasMode(Mode.NOSPAM)) {
             BoltComponents.sendMessage(
                     player,
                     Translation.CLICK_UNLOCKED,
                     plugin.isUseActionBar(),
                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                    Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
             );
         }
     }

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -54,6 +54,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.popcraft.bolt.BoltPlugin;
 import org.popcraft.bolt.access.Access;
 import org.popcraft.bolt.event.LockEntityEvent;
+import org.popcraft.bolt.event.ProtectionInteractEvent;
 import org.popcraft.bolt.lang.Translation;
 import org.popcraft.bolt.protection.BlockProtection;
 import org.popcraft.bolt.protection.EntityProtection;
@@ -163,13 +164,15 @@ public final class EntityListener extends InteractionListener implements Listene
         }
         final EntityProtection newProtection = plugin.createProtection(entity, player.getUniqueId(), access.type());
         plugin.saveProtection(newProtection);
+        ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(newProtection, Protections.displayType(entity, player));
+        plugin.getEventBus().post(protectionInteractEvent);
         if (!plugin.player(player.getUniqueId()).hasMode(Mode.NOSPAM)) {
             BoltComponents.sendMessage(
                     player,
                     Translation.CLICK_LOCKED,
                     plugin.isUseActionBar(),
                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(newProtection, player)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(entity, player))
+                    Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
             );
         }
     }
@@ -183,12 +186,14 @@ public final class EntityListener extends InteractionListener implements Listene
         }
         plugin.removeProtection(protection);
         if (e.getEntity().getLastDamageCause() instanceof EntityDamageByEntityEvent entityDamageByEntityEvent && getDamagerSource(entityDamageByEntityEvent.getDamager()) instanceof final Player player && plugin.canAccess(protection, player, Permission.DESTROY)) {
+            ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, Protections.displayType(entity, player));
+            plugin.getEventBus().post(protectionInteractEvent);
             BoltComponents.sendMessage(
                     player,
                     Translation.CLICK_UNLOCKED,
                     plugin.isUseActionBar(),
                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                    Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
             );
         }
     }
@@ -237,13 +242,15 @@ public final class EntityListener extends InteractionListener implements Listene
                     return;
                 }
                 plugin.removeProtection(protection);
+                ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, Protections.displayType(entity, player));
+                plugin.getEventBus().post(protectionInteractEvent);
                 if (plugin.canAccess(protection, player, Permission.DESTROY)) {
                     BoltComponents.sendMessage(
                             player,
                             Translation.CLICK_UNLOCKED,
                             plugin.isUseActionBar(),
                             Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
                     );
                 }
             }
@@ -275,13 +282,15 @@ public final class EntityListener extends InteractionListener implements Listene
                 plugin.saveProtection(entityProtection);
             }
             if (!canAccess) {
+                ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, Protections.displayType(entity, player));
+                plugin.getEventBus().post(protectionInteractEvent);
                 shouldCancel = true;
                 if (shouldSendMessage && !hasNotifyPermission) {
                     BoltComponents.sendMessage(
                             player,
                             Translation.LOCKED,
                             plugin.isUseActionBar(),
-                            Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                            Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
                     );
                 }
             }
@@ -298,12 +307,14 @@ public final class EntityListener extends InteractionListener implements Listene
                             if (!plugin.isProtected(entity)) {
                                 return;
                             }
+                            ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, Protections.displayType(entity, player));
+                            plugin.getEventBus().post(protectionInteractEvent);
                             BoltComponents.sendMessage(
                                     player,
                                     Translation.PROTECTION_NOTIFY_GENERIC,
                                     plugin.isUseActionBar(),
                                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
                             );
                         });
                     } else if (!isYou || player.hasPermission("bolt.protection.notify.self")) {
@@ -311,12 +322,14 @@ public final class EntityListener extends InteractionListener implements Listene
                             if (!plugin.isProtected(entity)) {
                                 return;
                             }
+                            ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, Protections.displayType(entity, player));
+                            plugin.getEventBus().post(protectionInteractEvent);
                             BoltComponents.sendMessage(
                                     player,
                                     Translation.PROTECTION_NOTIFY,
                                     plugin.isUseActionBar(),
                                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName()),
                                     Placeholder.component(Translation.Placeholder.PLAYER, Component.text(owner))
                             );
                         });
@@ -340,12 +353,14 @@ public final class EntityListener extends InteractionListener implements Listene
             e.setCancelled(true);
         } else {
             plugin.removeProtection(protection);
+            ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, Protections.displayType(vehicle, player));
+            plugin.getEventBus().post(protectionInteractEvent);
             BoltComponents.sendMessage(
                     player,
                     Translation.CLICK_UNLOCKED,
                     plugin.isUseActionBar(),
                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                    Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName())
             );
         }
     }

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/InteractionListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/InteractionListener.java
@@ -10,6 +10,7 @@ import org.popcraft.bolt.access.Access;
 import org.popcraft.bolt.event.Cancellable;
 import org.popcraft.bolt.event.LockBlockEvent;
 import org.popcraft.bolt.event.LockEntityEvent;
+import org.popcraft.bolt.event.ProtectionInteractEvent;
 import org.popcraft.bolt.lang.Translation;
 import org.popcraft.bolt.protection.Protection;
 import org.popcraft.bolt.util.Action;
@@ -39,16 +40,20 @@ abstract class InteractionListener {
         final boolean protectable = plugin.isProtectable(block);
         final ProtectableConfig config = plugin.getProtectableConfig(block);
         final Component displayName = Protections.displayType(block, player);
+        ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, displayName);
+        plugin.getEventBus().post(protectionInteractEvent);
         final String lockPermission = "bolt.protection.lock.%s".formatted(block.getType().name().toLowerCase());
-        return triggerAction(player, protection, block, protectable, config, displayName, lockPermission);
+        return triggerAction(player, protection, block, protectable, config, protectionInteractEvent.getProtectionName(), lockPermission);
     }
 
     protected boolean triggerAction(final Player player, final Protection protection, final Entity entity) {
         final boolean protectable = plugin.isProtectable(entity);
         final ProtectableConfig config = plugin.getProtectableConfig(entity);
         final Component displayName = Protections.displayType(entity, player);
+        ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, displayName);
+        plugin.getEventBus().post(protectionInteractEvent);
         final String lockPermission = "bolt.protection.lock.%s".formatted(entity.getType().name().toLowerCase());
-        return triggerAction(player, protection, entity, protectable, config, displayName, lockPermission);
+        return triggerAction(player, protection, entity, protectable, config, protectionInteractEvent.getProtectionName(), lockPermission);
     }
 
     private boolean triggerAction(final Player player, final Protection protection, final Object object, final boolean protectable, final ProtectableConfig config, final Component displayName, final String lockPermission) {
@@ -102,7 +107,7 @@ abstract class InteractionListener {
                                 player,
                                 Translation.CLICK_LOCKED_ALREADY,
                                 plugin.isUseActionBar(),
-                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                                Placeholder.component(Translation.Placeholder.PROTECTION, displayName)
                         );
                     }
                 } else if ((protectable || action.isAdmin()) && (!requiresLockPermission || player.hasPermission(lockPermission))) {
@@ -142,7 +147,7 @@ abstract class InteractionListener {
                                 Translation.CLICK_UNLOCKED,
                                 plugin.isUseActionBar(),
                                 Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                                Placeholder.component(Translation.Placeholder.PROTECTION, displayName)
                         );
                     } else {
                         BoltComponents.sendMessage(
@@ -169,7 +174,7 @@ abstract class InteractionListener {
                                     player,
                                     showFull ? (showAccessList ? Translation.INFO_FULL_ACCESS : Translation.INFO_FULL_NO_ACCESS) : Translation.INFO,
                                     Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                                    Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
+                                    Placeholder.component(Translation.Placeholder.PROTECTION, displayName),
                                     Placeholder.component(Translation.Placeholder.PLAYER, Optional.ofNullable(profile.name()).<Component>map(Component::text).orElse(resolveTranslation(Translation.UNKNOWN, player))),
                                     Placeholder.component(Translation.Placeholder.ACCESS_LIST_SIZE, Component.text(protection.getAccess().size())),
                                     Placeholder.component(Translation.Placeholder.ACCESS_LIST, Protections.accessList(protection.getAccess(), player)),
@@ -201,7 +206,7 @@ abstract class InteractionListener {
                                 Translation.CLICK_EDITED,
                                 plugin.isUseActionBar(),
                                 Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                                Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player))
+                                Placeholder.component(Translation.Placeholder.PROTECTION, displayName)
                         );
                     } else {
                         BoltComponents.sendMessage(
@@ -235,7 +240,7 @@ abstract class InteractionListener {
                                         Translation.CLICK_TRANSFER_CONFIRM,
                                         plugin.isUseActionBar(),
                                         Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, player)),
-                                        Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, player)),
+                                        Placeholder.component(Translation.Placeholder.PROTECTION, displayName),
                                         Placeholder.component(Translation.Placeholder.PLAYER, Optional.ofNullable(profile.name()).<Component>map(Component::text).orElse(resolveTranslation(Translation.UNKNOWN, player)))
                                 )));
                     } else {

--- a/bukkit/src/main/java/org/popcraft/bolt/util/Pagination.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/util/Pagination.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.popcraft.bolt.BoltPlugin;
 import org.popcraft.bolt.data.Profile;
+import org.popcraft.bolt.event.ProtectionInteractEvent;
 import org.popcraft.bolt.lang.Translation;
 import org.popcraft.bolt.lang.Translator;
 import org.popcraft.bolt.protection.BlockProtection;
@@ -64,12 +65,15 @@ public class Pagination {
             final Profile profile = Profiles.findProfileByUniqueId(protection.getOwner());
             final Component name = Optional.ofNullable(profile.name()).<Component>map(Component::text).orElse(resolveTranslation(Translation.UNKNOWN, sender));
 
+            ProtectionInteractEvent protectionInteractEvent = new ProtectionInteractEvent(protection, Protections.displayType(protection, sender));
+            plugin.getEventBus().post(protectionInteractEvent);
+
             if (location == null) {
                 BoltComponents.sendMessage(
                         sender,
                         Translation.FIND_RESULT_UNKNOWN,
                         Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, sender)),
-                        Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, sender)),
+                        Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName()),
                         Placeholder.component(Translation.Placeholder.PLAYER, name),
                         Placeholder.component(Translation.Placeholder.TIME, Time.relativeTimestamp(protection.getCreated(), sender, 1))
                 );
@@ -92,7 +96,7 @@ public class Pagination {
                         sender,
                         Translation.FIND_RESULT,
                         Placeholder.component(Translation.Placeholder.PROTECTION_TYPE, Protections.protectionType(protection, sender)),
-                        Placeholder.component(Translation.Placeholder.PROTECTION, Protections.displayType(protection, sender)),
+                        Placeholder.component(Translation.Placeholder.PROTECTION, protectionInteractEvent.getProtectionName()),
                         Placeholder.component(Translation.Placeholder.PLAYER, name),
                         Placeholder.component(Translation.Placeholder.TIME, Time.relativeTimestamp(protection.getCreated(), sender, 1)),
                         Placeholder.component(Translation.Placeholder.WORLD, Component.text(Objects.requireNonNull(location.getWorld()).getName())),


### PR DESCRIPTION
Adds a new event for any time a player interacts with a protection that allows mutating the protection name that shows up in chat.

I'm happy to adjust the PR to meet any requirements necessary for merging!

Sample integration:
```
        boltAPI.registerListener(ProtectionInteractEvent.class, event -> {
            if (!(event.getProtection() instanceof BlockProtection)) {
                return;
            }

            BlockProtection protection = (BlockProtection) event.getProtection();

            Block block = Bukkit.getWorld(protection.getWorld()).getBlockAt(protection.getX(), protection.getY(), protection.getZ());

            SlimefunItem sfItem = BlockStorage.check(block);
            if (sfItem == null) {
                return;
            }

            event.setProtectionName(org.popcraft.bolt.lib.net.kyori.adventure.text.Component.text(sfItem.getItemName()));
        });
```

Demo images from integrating this event with my Slimefun fork:
<img width="1903" height="1222" alt="image" src="https://github.com/user-attachments/assets/212caf26-524e-4401-93eb-b5858b6faab9" />
<img width="968" height="315" alt="image" src="https://github.com/user-attachments/assets/0112c4ee-a550-4127-acf7-e93ed3ecbd68" />
<img width="1655" height="904" alt="image" src="https://github.com/user-attachments/assets/d33f23fb-3d08-40f2-88b8-b8ee3347d78c" />
<img width="1767" height="1117" alt="image" src="https://github.com/user-attachments/assets/9fc22fe9-f649-4ca3-bef7-3b52d5b7cb54" />
