### PR TITLE
Copper golem access control

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/BoltPlugin.java
@@ -62,6 +62,7 @@ import org.popcraft.bolt.listeners.adapter.AnvilDamagedListener;
 import org.popcraft.bolt.listeners.adapter.BlockBreakBlockEventListener;
 import org.popcraft.bolt.listeners.adapter.BlockDestroyListener;
 import org.popcraft.bolt.listeners.adapter.BlockPreDispenseListener;
+import org.popcraft.bolt.listeners.adapter.ItemTransportingEntityValidateTargetEventListener;
 import org.popcraft.bolt.listeners.adapter.PlayerRecipeBookClickListener;
 import org.popcraft.bolt.matcher.Match;
 import org.popcraft.bolt.matcher.block.AmethystClusterMatcher;
@@ -156,7 +157,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -459,7 +459,11 @@ public class BoltPlugin extends JavaPlugin implements BoltAPI {
             pluginManager.registerEvents(new BlockDestroyListener(blockListener::onBlockDestroy), this);
             pluginManager.registerEvents(new BlockBreakBlockEventListener(blockListener::onBlockBreakBlockEvent), this);
         }
-        pluginManager.registerEvents(new EntityListener(this), this);
+        final EntityListener entityListener = new EntityListener(this);
+        pluginManager.registerEvents(entityListener, this);
+        if (ItemTransportingEntityValidateTargetEventListener.canUse()) {
+            pluginManager.registerEvents(new ItemTransportingEntityValidateTargetEventListener(entityListener::onItemTransportingEntityValidateTarget), this);
+        }
         final InventoryListener inventoryListener = new InventoryListener(this);
         pluginManager.registerEvents(inventoryListener, this);
         if (PaperUtil.isPaper()) {

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -5,6 +5,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
@@ -64,6 +65,8 @@ import org.popcraft.bolt.source.SourceTypeResolver;
 import org.popcraft.bolt.source.SourceTypes;
 import org.popcraft.bolt.util.BoltComponents;
 import org.popcraft.bolt.util.BoltPlayer;
+import org.popcraft.bolt.util.BukkitPlayerResolver;
+import org.popcraft.bolt.util.EnumUtil;
 import org.popcraft.bolt.util.Mode;
 import org.popcraft.bolt.util.Permission;
 import org.popcraft.bolt.util.Profiles;
@@ -75,12 +78,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import static org.popcraft.bolt.util.BoltComponents.translateRaw;
 
 public final class EntityListener extends InteractionListener implements Listener {
     private static final SourceResolver ENTITY_SOURCE_RESOLVER = new SourceTypeResolver(Source.of(SourceTypes.ENTITY));
+    private static final EntityType COPPER_GOLEM = EnumUtil.valueOf(EntityType.class, "COPPER_GOLEM").orElse(null);
     private final Map<NamespacedKey, UUID> spawnEggPlayers = new HashMap<>();
 
     public EntityListener(final BoltPlugin plugin) {
@@ -650,6 +656,32 @@ public final class EntityListener extends InteractionListener implements Listene
             blockProtection.setBlock(e.getTo().name());
             plugin.saveProtection(blockProtection);
         }
+    }
+
+    public void onItemTransportingEntityValidateTarget(Entity entity, Block block, Consumer<Boolean> setAllowed) {
+        final Protection blockProtection = plugin.findProtection(block);
+        if (blockProtection == null) {
+            return;
+        }
+        final Protection entityProtection = plugin.findProtection(entity);
+        final SourceResolver resolver =
+                entityProtection != null ? new BukkitPlayerResolver(this.plugin.getBolt(), entityProtection.getOwner()) : ENTITY_SOURCE_RESOLVER;
+        // Future: replace with entity instanceof CopperGolem or something
+        if (entity instanceof LivingEntity livingEntity && entity.getType() == COPPER_GOLEM) {
+            // For copper golems, we know if they're depositing or withdrawing based on if they're holding something.
+            final boolean isPickingUpItem = Objects.requireNonNull(livingEntity.getEquipment()).getItemInMainHand().getAmount() == 0;
+            final String permission = isPickingUpItem ? Permission.WITHDRAW : Permission.DEPOSIT;
+            if (!plugin.canAccess(blockProtection, resolver, permission)) {
+                setAllowed.accept(false);
+            }
+        } else {
+            // A plugin has added the item transporting goal to some other entity. Apparently according to Paper this is
+            // valid, but Bolt can't really know what the entity is doing, so just assume both withdrawing and depositing.
+            if (!plugin.canAccess(blockProtection, resolver, Permission.WITHDRAW, Permission.DEPOSIT)) {
+                setAllowed.accept(false);
+            }
+        }
+
     }
 
     private Entity getDamagerSource(final Entity damager) {

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-    compileOnly(group = "io.papermc.paper", name = "paper-api", version = "1.20.6-R0.1-SNAPSHOT")
+    compileOnly(group = "io.papermc.paper", name = "paper-api", version = "1.21.9-R0.1-SNAPSHOT")
 }

--- a/paper/src/main/java/org/popcraft/bolt/listeners/adapter/ItemTransportingEntityValidateTargetEventListener.java
+++ b/paper/src/main/java/org/popcraft/bolt/listeners/adapter/ItemTransportingEntityValidateTargetEventListener.java
@@ -1,0 +1,30 @@
+package org.popcraft.bolt.listeners.adapter;
+
+import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import java.util.function.Consumer;
+
+public record ItemTransportingEntityValidateTargetEventListener(Handler handler) implements Listener {
+    public static boolean canUse() {
+        try {
+            Class.forName("io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    @EventHandler
+    public void onItemTransportingEntityValidateTarget(final ItemTransportingEntityValidateTargetEvent e) {
+        handler.accept(e.getEntity(), e.getBlock(), e::setAllowed);
+    }
+
+    @FunctionalInterface
+    public interface Handler {
+        void accept(Entity entity, Block block, Consumer<Boolean> setAllowed);
+    }
+}


### PR DESCRIPTION
Prevent copper golems from accessing inventories their owner cannot access. In the case of unlocked copper golems, use the entity source.