### PR TITLE
Fix Folia detection

### DIFF
--- a/folia/src/main/java/org/popcraft/bolt/util/FoliaUtil.java
+++ b/folia/src/main/java/org/popcraft/bolt/util/FoliaUtil.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 public class FoliaUtil {
-    private static final boolean CONFIG_EXISTS = classExists("io.papermc.paper.threadedregions.RegionizedServer") || classExists("io.papermc.paper.threadedregions.RegionizedServerInitEvent");
+    private static final boolean CONFIG_EXISTS = classExists("io.papermc.paper.threadedregions.RegionizedServer");
 
     private FoliaUtil() {
     }


### PR DESCRIPTION
As now, Paper has included the `io.papermc.paper.threadedregions.RegionizedServerInitEvent` class, Bolt will detect modern Paper as Folia and do extra safety check stuff that is not needed.