### PR TITLE
Don't assume waterlogged blocks get destroyed by water

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -494,6 +494,10 @@ public final class BlockListener extends InteractionListener implements Listener
             if (!plugin.canAccess(protection, player, Permission.INTERACT, Permission.WITHDRAW)) {
                 e.setCancelled(true);
             }
+        } else if (e.getBlock().getBlockData() instanceof Waterlogged) {
+            if (!plugin.canAccess(protection, player, Permission.INTERACT)) {
+                e.setCancelled(true);
+            }
         }
     }
 


### PR DESCRIPTION
Emptying a bucket into a block which can be waterlogged simply changes its block data. Count it as an interaction.