### PR TITLE
Fix replaceable interaction with matchers

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -227,7 +227,7 @@ public final class BlockListener extends InteractionListener implements Listener
         if (protection == null) {
             return;
         }
-        if (Tag.REPLACEABLE.isTagged(e.getBlockReplacedState().getType())) {
+        if (Tag.REPLACEABLE.isTagged(replaced.getType()) && protection instanceof BlockProtection blockProtection && blockProtection.getBlock().equals(replaced.getType().toString())) {
             // Prevent accidental deletion of protected blocks by them getting replaced.
             // Purposefully not checking for destroy permissions, that logic is for BlockBreakEvent.
             e.setCancelled(true);


### PR DESCRIPTION
Bolt checks if a block is replaceable based on the replaced block state, but runs matchers based on the new block state. This can cause situations where Bolt matches a chest protection, assuming the replaced block is a chest, while also thinking its a replaceable block, thus cancelling the place.

This patch checks that the replaced block is of the same type as the protection. This is because replaceable blocks, if protected, would only match themselves, and they cannot support other blocks.