### PR TITLE
Update gradle wrapper validation action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Gradle wrapper validation
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v6
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The old version we have seems to struggle with network issues (https://github.com/gradle/actions/issues/631). The updated version allegedly handles this better