### PR TITLE
Fix shelf double interact

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -97,29 +97,25 @@ public final class BlockListener extends InteractionListener implements Listener
         }
         final Player player = e.getPlayer();
         final BoltPlayer boltPlayer = plugin.player(player);
-        if (boltPlayer.hasInteracted()) {
-            if (boltPlayer.isInteractionCancelled()) {
-                e.setCancelled(true);
-            }
-            return;
-        }
+        // First interaction in this tick, to avoid some double actions when both hands are sent as events.
+        final boolean firstInteraction = !boltPlayer.hasInteracted();
         final Protection protection = plugin.findProtection(clicked);
         boolean shouldCancel = false;
         boolean interacted = false;
-        if (triggerAction(player, protection, clicked)) {
+        if (firstInteraction && triggerAction(player, protection, clicked)) {
             interacted = true;
             shouldCancel = true;
         } else if (protection != null) {
             final boolean hasNotifyPermission = player.hasPermission("bolt.protection.notify");
             final boolean canInteract = plugin.canAccess(protection, player, Permission.INTERACT);
             interacted = true;
-            if (canInteract && protection instanceof final BlockProtection blockProtection) {
+            if (canInteract && firstInteraction && protection instanceof final BlockProtection blockProtection) {
                 protection.setAccessed(System.currentTimeMillis());
                 plugin.saveProtection(blockProtection);
             }
             if (!canInteract) {
                 shouldCancel = true;
-                if (!hasNotifyPermission) {
+                if (!hasNotifyPermission && firstInteraction) {
                     BoltComponents.sendMessage(
                             player,
                             Translation.LOCKED,
@@ -128,10 +124,10 @@ public final class BlockListener extends InteractionListener implements Listener
                     );
                 }
             }
-            if (plugin.isDoors() && canInteract) {
+            if (plugin.isDoors() && firstInteraction && canInteract) {
                 Doors.handlePlayerInteract(plugin, e);
             }
-            if (hasNotifyPermission) {
+            if (hasNotifyPermission && firstInteraction) {
                 Profiles.findOrLookupProfileByUniqueId(protection.getOwner()).thenAccept(profile -> {
                     final boolean noSpam = plugin.player(player.getUniqueId()).hasMode(Mode.NOSPAM);
                     if (noSpam) {
@@ -213,7 +209,7 @@ public final class BlockListener extends InteractionListener implements Listener
             }
         }
         if (interacted) {
-            boltPlayer.setInteracted(shouldCancel);
+            boltPlayer.setInteracted();
             SchedulerUtil.schedule(plugin, player, boltPlayer::clearInteraction);
         }
         if (shouldCancel) {

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -105,13 +105,14 @@ public final class BlockListener extends InteractionListener implements Listener
         }
         final Protection protection = plugin.findProtection(clicked);
         boolean shouldCancel = false;
+        boolean interacted = false;
         if (triggerAction(player, protection, clicked)) {
-            boltPlayer.setInteracted(true);
-            SchedulerUtil.schedule(plugin, player, boltPlayer::clearInteraction);
+            interacted = true;
             shouldCancel = true;
         } else if (protection != null) {
             final boolean hasNotifyPermission = player.hasPermission("bolt.protection.notify");
             final boolean canInteract = plugin.canAccess(protection, player, Permission.INTERACT);
+            interacted = true;
             if (canInteract && protection instanceof final BlockProtection blockProtection) {
                 protection.setAccessed(System.currentTimeMillis());
                 plugin.saveProtection(blockProtection);
@@ -195,8 +196,6 @@ public final class BlockListener extends InteractionListener implements Listener
                     e.setUseInteractedBlock(Event.Result.DENY);
                 }
             }
-            boltPlayer.setInteracted(shouldCancel);
-            SchedulerUtil.schedule(plugin, player, boltPlayer::clearInteraction);
         }
         // Future: use Tag.WOODEN_SHELVES
         // todo: get slot once api is added for it, but then need to watch out for powered shelves, which always make a swap operation
@@ -205,11 +204,17 @@ public final class BlockListener extends InteractionListener implements Listener
             final List<Block> connected = ConnectedShelves.connectedShelves(clicked);
             for (Block shelf : connected) {
                 final Protection shelfProtection = plugin.loadProtection(shelf);
+                if (shelfProtection != null) {
+                    interacted = true;
+                }
                 if (!plugin.canAccess(shelfProtection, player, Permission.DEPOSIT, Permission.WITHDRAW)) {
-                    e.setUseItemInHand(Event.Result.DENY);
-                    e.setUseInteractedBlock(Event.Result.DENY);
+                    shouldCancel = true;
                 }
             }
+        }
+        if (interacted) {
+            boltPlayer.setInteracted(shouldCancel);
+            SchedulerUtil.schedule(plugin, player, boltPlayer::clearInteraction);
         }
         if (shouldCancel) {
             e.setCancelled(true);

--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/EntityListener.java
@@ -301,26 +301,25 @@ public final class EntityListener extends InteractionListener implements Listene
             return false;
         }
         final BoltPlayer boltPlayer = plugin.player(player);
-        if (boltPlayer.hasInteracted()) {
-            return true;
-        }
+        // First interaction in this tick, to avoid some double actions when both hands are sent as events.
+        final boolean firstInteraction = !boltPlayer.hasInteracted();
         boolean shouldCancel = false;
         final Protection protection = plugin.findProtection(entity);
-        if (triggerAction(player, protection, entity)) {
-            boltPlayer.setInteracted(true);
+        if (firstInteraction && triggerAction(player, protection, entity)) {
+            boltPlayer.setInteracted();
             SchedulerUtil.schedule(plugin, player, boltPlayer::clearInteraction);
             shouldCancel = true;
         } else if (protection != null) {
             final boolean hasNotifyPermission = player.hasPermission("bolt.protection.notify");
             final boolean canAccess = plugin.canAccess(protection, player, permission);
             final boolean canInteract = canAccess && Permission.INTERACT.equals(permission);
-            if (canInteract && protection instanceof final EntityProtection entityProtection) {
+            if (canInteract && firstInteraction && protection instanceof final EntityProtection entityProtection) {
                 protection.setAccessed(System.currentTimeMillis());
                 plugin.saveProtection(entityProtection);
             }
             if (!canAccess) {
                 shouldCancel = true;
-                if (shouldSendMessage && !hasNotifyPermission) {
+                if (shouldSendMessage && firstInteraction && !hasNotifyPermission) {
                     BoltComponents.sendMessage(
                             player,
                             Translation.LOCKED,
@@ -329,7 +328,7 @@ public final class EntityListener extends InteractionListener implements Listene
                     );
                 }
             }
-            if (shouldSendMessage && hasNotifyPermission) {
+            if (shouldSendMessage && firstInteraction && hasNotifyPermission) {
                 Profiles.findOrLookupProfileByUniqueId(protection.getOwner()).thenAccept(profile -> {
                     final boolean noSpam = plugin.player(player.getUniqueId()).hasMode(Mode.NOSPAM);
                     if (noSpam) {
@@ -367,7 +366,7 @@ public final class EntityListener extends InteractionListener implements Listene
                     }
                 });
             }
-            boltPlayer.setInteracted(shouldCancel);
+            boltPlayer.setInteracted();
             SchedulerUtil.schedule(plugin, player, boltPlayer::clearInteraction);
         }
         return shouldCancel;

--- a/common/src/main/java/org/popcraft/bolt/util/BoltPlayer.java
+++ b/common/src/main/java/org/popcraft/bolt/util/BoltPlayer.java
@@ -16,7 +16,6 @@ public class BoltPlayer {
     private Action action;
     private Action lastAction;
     private boolean interacted;
-    private boolean interactionCancelled;
     private boolean trusting;
     private boolean trustingSilently;
     private boolean lockNil;
@@ -54,19 +53,13 @@ public class BoltPlayer {
         return interacted;
     }
 
-    public boolean isInteractionCancelled() {
-        return interactionCancelled;
-    }
-
-    public void setInteracted(final boolean cancelled) {
+    public void setInteracted() {
         this.interacted = true;
-        this.interactionCancelled = cancelled;
     }
 
     public void clearInteraction() {
         this.lastAction = null;
         this.interacted = false;
-        this.interactionCancelled = false;
     }
 
     public boolean hasMode(final Mode mode) {


### PR DESCRIPTION
Bolt has detection for two interactions events in the same tick. Due to the way shelves needed to be implemented due to their connected nature, they weren't properly integrated into this system. If interacting with the shelf was allowed but depositing or withdrawing isn't, Bolt would save that an interaction happened, but wrongfully saves that it wasn't cancelled. Later in the same tick, if another interaction happens, Bolt remembers that the previous interaction wasn't cancelled, and allows this interaction, too, allowing for the stealing of items.

This patch updates the logic so that permission checks are always performed even in the second interaction in a tick, but keeps the detection around to prevent duplicate messages. Only skips the action triggers, access time updates, doors, and message sending, but still performs all permission checks and corresponding cancelling.

Fixes https://github.com/pop4959/Bolt/issues/260