### PR TITLE
Prevent autoprotection on block modification

### DIFF
--- a/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
+++ b/bukkit/src/main/java/org/popcraft/bolt/listeners/BlockListener.java
@@ -230,6 +230,7 @@ public final class BlockListener extends InteractionListener implements Listener
         }
         final Player player = e.getPlayer();
         // The below handles only special cases for block placement (replacing and placement causing modification)
+        // Future: use BlockData.isReplaceable, which is only available from Paper 1.21.10 onwards.
         if (Tag.REPLACEABLE.isTagged(replaced.getType())) {
             // Prevent deletion of protected blocks by them getting replaced.
             if (!plugin.canAccess(block, player, Permission.DESTROY)) {
@@ -252,6 +253,12 @@ public final class BlockListener extends InteractionListener implements Listener
         }
         final Block block = e.getBlock();
         if (!plugin.isProtectable(block)) {
+            return;
+        }
+        final BlockState replaced = e.getBlockReplacedState();
+        // This is actually a block modification, not a replacement, and the block wasn't protected, so don't autoprotect it.
+        // Future: use BlockData.isReplaceable, which is only available from Paper 1.21.10 onwards.
+        if (!plugin.isProtected(block) && !replaced.getType().isAir() && !Tag.REPLACEABLE.isTagged(replaced.getType())) {
             return;
         }
         final ProtectableConfig protectableConfig = plugin.getProtectableConfig(block);


### PR DESCRIPTION
BlockPlaceEvent is called, in addition to placing blocks, when modifying certain blocks. Because Bolt currently doesn't distinguish these, modifying a block which has autoprotect enabled causes modifications to be counted as placements.

This patch makes it so blocks which weren't protected to begin with do not get autoprotected if only a modification took place, not a placement.

Note that Tag.REPLACEABLE is technically imperfect, but the proper API method isn't available on our lowest supported version.

Fixes https://github.com/pop4959/Bolt/issues/262